### PR TITLE
Updating libraries folder name to avoid confusion with root lib folder

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -3,7 +3,7 @@
 @import './release-candidate/index.scss';
 
 // External libraries first
-@import "./lib/lib";
+@import "./libraries/libraries";
 
 // masterSass
 @import "./base/base";

--- a/src/styles/libraries/_libraries.scss
+++ b/src/styles/libraries/_libraries.scss
@@ -1,0 +1,7 @@
+// External or internal libraries
+
+// Reset
+@import "reset";
+
+// Bootstrap Grid
+@import "node_modules/bootstrap/scss/bootstrap-grid";

--- a/src/styles/libraries/reset.scss
+++ b/src/styles/libraries/reset.scss
@@ -1,0 +1,55 @@
+/* stylelint-disable */
+
+/* http://meyerweb.com/eric/tools/css/reset/
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, button, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol, ul {
+  list-style: none;
+}
+blockquote, q {
+  quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+/* Also enable box-sizing */
+* { box-sizing: border-box; }
+/* stylelint-enable */


### PR DESCRIPTION
The `gitignore` file excludes the root `lib` folder, so this PR updates the name of the lib folder inside of the old mastersass structure to `libraries` instead.