### PR TITLE
Updating documentation on how to deploy storybook to github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ const Container = () =>
 1. Clone the repository
 2. Install dependencies: `yarn`
 3. Start the storybook: `yarn storybook`
+
+## Documentation
+All documentation is handled in storybook.  To deploy a new version of the [styleguide](https://yankaindustries.github.io/mc-components), run the following command from the root directory:
+
+```
+npm run deploy-storybook
+```


### PR DESCRIPTION
The tool was already implemented, adding documentation on how to deploy to github pages.

## Risks
No

## Changes
Updates readme

## Issue
https://github.com/yankaindustries/mc-components/issues/3
