### PR TITLE
Fix Radio Input text alignment

### DIFF
--- a/src/styles/release-candidate/components/_radio-input.scss
+++ b/src/styles/release-candidate/components/_radio-input.scss
@@ -1,6 +1,7 @@
 .radio-input {
   display: flex;
   padding: 0 .6rem;
+  align-items: center;
 
   &:not(:last-child) {
     margin-bottom: 1.6rem;


### PR DESCRIPTION
Radio Input label was not centered

## Risks
None

## Changes
### Before
<img width="159" alt="screen shot 2018-06-15 at 12 30 04 pm" src="https://user-images.githubusercontent.com/18464392/41476794-f56af886-7098-11e8-8357-978145ed18e8.png">

### After
<img width="163" alt="screen shot 2018-06-15 at 12 34 43 pm" src="https://user-images.githubusercontent.com/18464392/41476815-fde41e52-7098-11e8-8f9d-99159bfb4436.png">
