### PR TITLE
Temporal disable prettier-eslint and lint --fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
   },
   "lint-staged": {
     "src/**/*.js": [
-      "eslint --fix",
-      "git add"
+      "yarn lint:js"
     ],
     "src/**/*.scss": [
       "stylelint --fix",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
   },
   "lint-staged": {
     "src/**/*.js": [
+      "eslint --fix",
+      "git add"
     ],
     "src/**/*.scss": [
       "stylelint --fix",


### PR DESCRIPTION
## Description
### What
Temporal disable prettier-eslint and eslint --fix, we should enable it again once we tackle this issue #36 
### Why:
`prettier-eslint` is uglifying the code

## Risks
No

## Changes
No visual changes

## Issue
#36 and #37 