### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:js": "NODE_ENV=production babel ./src --out-dir ./dist --ignore spec.js,test.js,stories.js",
     "prebuild:css": "node-sass src/styles/index.scss dist/styles/css/mastersass.css",
     "build:css": "postcss -r dist/styles/css/mastersass.css",
-    "build:css-vendor": "node-sass src/styles/libraries/_libraries.scss dist/styles/css/vendor.css",
+    "build:css-vendor": "node-sass src/styles/libraries/_libraries.scss dist/styles/css/vendor.css && postcss -r dist/styles/css/vendor.css",
     "build:scss": "cpx -p './src/styles/**/*.scss' ./dist/styles/scss",
     "build:styles": "yarn build:scss && yarn build:css",
     "test": "jest",

--- a/src/styles/libraries/_libraries.scss
+++ b/src/styles/libraries/_libraries.scss
@@ -8,4 +8,3 @@
 @import "node_modules/bootstrap/scss/bootstrap-grid";
 @import "bootstrap-overrides/grid";
 @import "~slick-carousel/slick/slick.css";
-@import "~slick-carousel/slick/slick-theme.css";


### PR DESCRIPTION
Remove unnecessary dependency (slick-theme.css). The carousel has its own styling, the theme stylesheet is no needed.
