### PR TITLE
Undoing manual versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "0.2.2",
+  "version": "0.2.0",
   "main": "./dist/index.js",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",


### PR DESCRIPTION
Versioning was done manually prior to this commit, so I've
- Unpublished 0.2.1 from npm
- Deleted 0.2.1 tag on github
- Manually reverted the package json back to 0.2.0 so it's able to be versioned with the script (it's currently on 0.2.2 which might cause issues with versioning next time)