### PR TITLE
Fix c button text color in hover state

### DIFF
--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -155,5 +155,9 @@
     &:after {
       background: rgba(255, 255, 255, 0.5);
     }
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.5);
+    }
   }
 }

--- a/src/styles/components/buttons/_button.scss
+++ b/src/styles/components/buttons/_button.scss
@@ -14,6 +14,9 @@
 
   &:hover {
     background: $mc-color-primary-hover;
+    // Needed to override old previously defined
+    // hover color in masterclass repo
+    color: $mc-light;
   }
 
   &:active {


### PR DESCRIPTION
When imported into the main masterclass repo, the c-button had the color of the button text chaned to red because of a previously defined color change on hover for anchor tags.  Instead of risking changing in masterclass repo, I'm specifying color on hover in this repo because it's lower risk (same color on default / hover).

## Risks
Could unintentionally affect text color on hover state if it isn't expecting to be white when using c-buttons (unlikely)

## Changes
No visual changes, fixes a bug in masterclass main repo

## Issue
N/A
