### PR TITLE
Tech debt: button cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
       "yarn lint:js"
     ],
     "src/**/*.scss": [
+      "yarn lint:style",
       "stylelint --fix",
       "git add"
     ]

--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -1,4 +1,5 @@
-.c-button {
+.c-button,
+.mc-c-btn {
   &--small {
     padding: 12px 16px;
   }

--- a/src/styles/components/buttons/_button.scss
+++ b/src/styles/components/buttons/_button.scss
@@ -1,4 +1,5 @@
-.c-button {
+.c-button,
+.mc-c-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Overview
There are a number of different legacy button types now in the main masterclass repo. We have `mc-btn`, `mc-button`, and now `c-button`, all of which have different variants that are slightly different.

This PR is the first step towards finally cleaning that up.  This pr adds a temporary class that mirrors `c-button` called `mc-c-btn`.  This is a unique enough name to do a find and replace after cleanup is complete.  My plan is to:

- Migrate all existing `mc-btn` and `mc-button` classes to those supported by `c-button` by using the new temporary `mc-c-btn` class. 
- Once **all** buttons are consolidated in the masterclass repo, I'll find and replace all instances of `mc-c-btn` to `mc-btn` and update the component class names as well.
- From this point on, `mc-btn` will be the only button type.

This PR also adds linting to the precommit step so we won't forget to check CSS before committing code!

## Risks
Low risk now, as this is adding a new class name.  High risk later when we remove all existing class names.

## Changes
No visual changes

## Issue
Starting to attack: https://github.com/yankaindustries/mc-components/issues/112