### PR TITLE
Adding position prop to TileCaption

### DIFF
--- a/.storybook/styles.scss
+++ b/.storybook/styles.scss
@@ -26,6 +26,10 @@ hr {
   border-radius: 6px;
 }
 
+.example--section {
+  margin-bottom: 6em;
+}
+
 .example--definition-name {
   font-weight: 900;
 }

--- a/src/components/AnimationHandler/__snapshots__/index.stories.storyshot
+++ b/src/components/AnimationHandler/__snapshots__/index.stories.storyshot
@@ -168,7 +168,7 @@ exports[`Storyshots utilities|AnimationHandler default 1`] = `
                     className="mc-tile__component mc-tile-overlay mc-tile-overlay--gradient-bottom "
                   />
                   <div
-                    className="mc-tile__component mc-tile-caption mc-animation mc-animation--lift "
+                    className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom mc-animation mc-animation--lift "
                   >
                     <div
                       className="mc-tile-caption__titles"

--- a/src/components/Tile/__snapshots__/index.stories.storyshot
+++ b/src/components/Tile/__snapshots__/index.stories.storyshot
@@ -86,7 +86,7 @@ exports[`Storyshots components|Tiles Summary 1`] = `
               className="mc-tile__content content"
             >
               <div
-                className="mc-tile__component mc-tile-caption "
+                className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
               >
                 <div
                   className="mc-tile-caption__titles"
@@ -275,7 +275,7 @@ exports[`Storyshots components|Tiles Summary 1`] = `
                       className="mc-tile__component mc-tile-overlay mc-tile-overlay--gradient-bottom "
                     />
                     <div
-                      className="mc-tile__component mc-tile-caption mc-animation mc-animation--lift "
+                      className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom mc-animation mc-animation--lift "
                     >
                       <div
                         className="mc-tile-caption__titles"
@@ -334,7 +334,7 @@ exports[`Storyshots components|Tiles Summary 1`] = `
                   className="mc-tile__component mc-tile-overlay mc-tile-overlay--gradient-bottom "
                 />
                 <div
-                  className="mc-tile__component mc-tile-caption "
+                  className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
                 >
                   <div
                     className="mc-tile-caption__titles"

--- a/src/components/TileCaption/__snapshots__/index.stories.storyshot
+++ b/src/components/TileCaption/__snapshots__/index.stories.storyshot
@@ -303,42 +303,90 @@ exports[`Storyshots components|Tiles/TileCaption TileCaption 1`] = `
                 className="col-sm-4"
               >
                 <div
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
+                  className="mc-tile mc-tile--16x9 "
                 >
                   <div
-                    className="mc-tile mc-tile--16x9 mc-animation mc-animation--zoom "
+                    className="mc-tile__content content"
                   >
                     <div
-                      className="mc-tile__content content"
+                      className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--below "
                     >
                       <div
-                        className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
+                        className="mc-tile-caption__titles"
                       >
-                        <div
-                          className="mc-tile-caption__titles"
+                        <h2
+                          className="mc-tile-caption__title"
                         >
-                          <h2
-                            className="mc-tile-caption__title"
-                          >
-                            Shonda Rhimes
-                          </h2>
-                          <h3
-                            className="mc-tile-caption__subtitle"
-                          >
-                            Teaches Writing
-                          </h3>
-                        </div>
-                      </div>
-                      <div
-                        className="example-placeholder"
-                      >
-                        <div
-                          className="example-placeholder__inner"
-                        />
+                          Shonda Rhimes
+                        </h2>
+                        <h3
+                          className="mc-tile-caption__subtitle"
+                        >
+                          Teaches Writing
+                        </h3>
                       </div>
                     </div>
+                    <div
+                      className="example-placeholder"
+                    >
+                      <div
+                        className="example-placeholder__inner"
+                      />
+                    </div>
                   </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="example--section"
+    >
+      <h4>
+        Example
+      </h4>
+      <div
+        className="row"
+      >
+        <div
+          className="col-sm-4"
+        >
+          <div
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <div
+              className="mc-tile mc-tile--16x9 mc-animation mc-animation--zoom "
+            >
+              <div
+                className="mc-tile__content content"
+              >
+                <div
+                  className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
+                >
+                  <div
+                    className="mc-tile-caption__titles"
+                  >
+                    <h2
+                      className="mc-tile-caption__title"
+                    >
+                      Shonda Rhimes
+                    </h2>
+                    <h3
+                      className="mc-tile-caption__subtitle"
+                    >
+                      Teaches Writing
+                    </h3>
+                  </div>
+                </div>
+                <div
+                  className="example-placeholder"
+                >
+                  <div
+                    className="example-placeholder__inner"
+                  />
                 </div>
               </div>
             </div>

--- a/src/components/TileCaption/__snapshots__/index.stories.storyshot
+++ b/src/components/TileCaption/__snapshots__/index.stories.storyshot
@@ -14,54 +14,54 @@ exports[`Storyshots components|Tiles/TileCaption TileCaption 1`] = `
       className="example--section"
     >
       <h4>
-        Props
+        Variants
       </h4>
       <div
-        className="row"
+        className="example--definition"
       >
         <div
-          className="col-md-6"
+          className="row"
         >
           <div
-            className="example--definition"
+            className="col-xs-10"
+          >
+            <h5>
+              <span
+                className="example--definition-name"
+              >
+                title
+              </span>
+              <span
+                className="example--definition-type"
+              >
+                 &lt;
+                String
+                &gt;
+              </span>
+            </h5>
+          </div>
+          <div
+            className="col-xs-2 text-right"
+          />
+        </div>
+        <div>
+          <div
+            className="text-right"
+          >
+            <a
+              onClick={[Function]}
+            >
+              &lt;/&gt;
+            </a>
+          </div>
+          <div
+            className="example--render"
           >
             <div
               className="row"
             >
               <div
-                className="col-xs-10"
-              >
-                <h5>
-                  <span
-                    className="example--definition-name"
-                  >
-                    title
-                  </span>
-                  <span
-                    className="example--definition-type"
-                  >
-                     &lt;
-                    String
-                    &gt;
-                  </span>
-                </h5>
-              </div>
-              <div
-                className="col-xs-2 text-right"
-              />
-            </div>
-            <div>
-              <div
-                className="text-right"
-              >
-                <a
-                  onClick={[Function]}
-                >
-                  &lt;/&gt;
-                </a>
-              </div>
-              <div
-                className="example--render"
+                className="col-sm-4"
               >
                 <div
                   className="mc-tile mc-tile--16x9 "
@@ -70,7 +70,7 @@ exports[`Storyshots components|Tiles/TileCaption TileCaption 1`] = `
                     className="mc-tile__content content"
                   >
                     <div
-                      className="mc-tile__component mc-tile-caption "
+                      className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
                     >
                       <div
                         className="mc-tile-caption__titles"
@@ -80,63 +80,68 @@ exports[`Storyshots components|Tiles/TileCaption TileCaption 1`] = `
                         >
                           Shonda Rhimes
                         </h2>
-                        <h3
-                          className="mc-tile-caption__subtitle"
-                        />
                       </div>
                     </div>
                     <div
-                      className="example__filler"
-                    />
+                      className="example-placeholder"
+                    >
+                      <div
+                        className="example-placeholder__inner"
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
+      </div>
+      <div
+        className="example--definition"
+      >
         <div
-          className="col-md-6"
+          className="row"
         >
           <div
-            className="example--definition"
+            className="col-xs-10"
+          >
+            <h5>
+              <span
+                className="example--definition-name"
+              >
+                subtitle
+              </span>
+              <span
+                className="example--definition-type"
+              >
+                 &lt;
+                String
+                &gt;
+              </span>
+            </h5>
+          </div>
+          <div
+            className="col-xs-2 text-right"
+          />
+        </div>
+        <div>
+          <div
+            className="text-right"
+          >
+            <a
+              onClick={[Function]}
+            >
+              &lt;/&gt;
+            </a>
+          </div>
+          <div
+            className="example--render"
           >
             <div
               className="row"
             >
               <div
-                className="col-xs-10"
-              >
-                <h5>
-                  <span
-                    className="example--definition-name"
-                  >
-                    subtitle
-                  </span>
-                  <span
-                    className="example--definition-type"
-                  >
-                     &lt;
-                    String
-                    &gt;
-                  </span>
-                </h5>
-              </div>
-              <div
-                className="col-xs-2 text-right"
-              />
-            </div>
-            <div>
-              <div
-                className="text-right"
-              >
-                <a
-                  onClick={[Function]}
-                >
-                  &lt;/&gt;
-                </a>
-              </div>
-              <div
-                className="example--render"
+                className="col-sm-4"
               >
                 <div
                   className="mc-tile mc-tile--16x9 "
@@ -145,7 +150,7 @@ exports[`Storyshots components|Tiles/TileCaption TileCaption 1`] = `
                     className="mc-tile__content content"
                   >
                     <div
-                      className="mc-tile__component mc-tile-caption "
+                      className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
                     >
                       <div
                         className="mc-tile-caption__titles"
@@ -163,8 +168,176 @@ exports[`Storyshots components|Tiles/TileCaption TileCaption 1`] = `
                       </div>
                     </div>
                     <div
-                      className="example__filler"
-                    />
+                      className="example-placeholder"
+                    >
+                      <div
+                        className="example-placeholder__inner"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="example--definition"
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-xs-10"
+          >
+            <h5>
+              <span
+                className="example--definition-name"
+              >
+                position
+              </span>
+              <span
+                className="example--definition-type"
+              >
+                 &lt;
+                String
+                &gt;
+              </span>
+            </h5>
+          </div>
+          <div
+            className="col-xs-2 text-right"
+          />
+        </div>
+        <div>
+          <div
+            className="text-right"
+          >
+            <a
+              onClick={[Function]}
+            >
+              &lt;/&gt;
+            </a>
+          </div>
+          <div
+            className="example--render"
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col-sm-4"
+              >
+                <div
+                  className="mc-tile mc-tile--16x9 "
+                >
+                  <div
+                    className="mc-tile__content content"
+                  >
+                    <div
+                      className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
+                    >
+                      <div
+                        className="mc-tile-caption__titles"
+                      >
+                        <h2
+                          className="mc-tile-caption__title"
+                        >
+                          Shonda Rhimes
+                        </h2>
+                        <h3
+                          className="mc-tile-caption__subtitle"
+                        >
+                          Teaches Writing
+                        </h3>
+                      </div>
+                    </div>
+                    <div
+                      className="example-placeholder"
+                    >
+                      <div
+                        className="example-placeholder__inner"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="col-sm-4"
+              >
+                <div
+                  className="mc-tile mc-tile--16x9 "
+                >
+                  <div
+                    className="mc-tile__content content"
+                  >
+                    <div
+                      className="mc-tile__component mc-tile-caption mc-tile-caption--center mc-tile-caption--bottom "
+                    >
+                      <div
+                        className="mc-tile-caption__titles"
+                      >
+                        <h2
+                          className="mc-tile-caption__title"
+                        >
+                          Shonda Rhimes
+                        </h2>
+                        <h3
+                          className="mc-tile-caption__subtitle"
+                        >
+                          Teaches Writing
+                        </h3>
+                      </div>
+                    </div>
+                    <div
+                      className="example-placeholder"
+                    >
+                      <div
+                        className="example-placeholder__inner"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="col-sm-4"
+              >
+                <div
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <div
+                    className="mc-tile mc-tile--16x9 mc-animation mc-animation--zoom "
+                  >
+                    <div
+                      className="mc-tile__content content"
+                    >
+                      <div
+                        className="mc-tile__component mc-tile-caption mc-tile-caption--left mc-tile-caption--bottom "
+                      >
+                        <div
+                          className="mc-tile-caption__titles"
+                        >
+                          <h2
+                            className="mc-tile-caption__title"
+                          >
+                            Shonda Rhimes
+                          </h2>
+                          <h3
+                            className="mc-tile-caption__subtitle"
+                          >
+                            Teaches Writing
+                          </h3>
+                        </div>
+                      </div>
+                      <div
+                        className="example-placeholder"
+                      >
+                        <div
+                          className="example-placeholder__inner"
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/TileCaption/index.js
+++ b/src/components/TileCaption/index.js
@@ -29,10 +29,13 @@ export default class TileCaption extends PureComponent {
       title,
     } = this.props
 
+    const positionClasses =
+      position.split(' ').map(pos => `mc-tile-caption--${pos}`)
+
     const classes = [
       'mc-tile__component',
       'mc-tile-caption',
-      `mc-tile-caption--${position.replace(' ', '-')}`,
+      ...positionClasses,
       className || '',
     ].join(' ')
 

--- a/src/components/TileCaption/index.js
+++ b/src/components/TileCaption/index.js
@@ -6,14 +6,25 @@ export default class TileCaption extends PureComponent {
   static propTypes = {
     children: PropTypes.element,
     className: PropTypes.string,
+    position: PropTypes.oneOf([
+      'left bottom',
+      'center bottom',
+      'left below',
+      'center below',
+    ]),
     subtitle: PropTypes.string,
     title: PropTypes.string,
+  }
+
+  static defaultProps = {
+    position: 'left bottom',
   }
 
   render () {
     const {
       children,
       className,
+      position,
       subtitle,
       title,
     } = this.props
@@ -21,14 +32,19 @@ export default class TileCaption extends PureComponent {
     const classes = [
       'mc-tile__component',
       'mc-tile-caption',
+      `mc-tile-caption--${position.replace(' ', '-')}`,
       className || '',
     ].join(' ')
 
     return (
       <div className={classes}>
         <div className='mc-tile-caption__titles'>
-          <h2 className='mc-tile-caption__title'>{title}</h2>
-          <h3 className='mc-tile-caption__subtitle'>{subtitle}</h3>
+          {title &&
+            <h2 className='mc-tile-caption__title'>{title}</h2>
+          }
+          {subtitle &&
+            <h3 className='mc-tile-caption__subtitle'>{subtitle}</h3>
+          }
         </div>
 
         {children &&

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -8,6 +8,8 @@ import Placeholder from '../../utils/Placeholder'
 
 import Tile from '../Tile'
 import TileCaption from '../TileCaption'
+import AnimationHandler from '../AnimationHandler'
+import HoverHandler from '../HoverHandler'
 
 
 storiesOf('components|Tiles/TileCaption', module)
@@ -59,6 +61,7 @@ storiesOf('components|Tiles/TileCaption', module)
                 <Tile>
                   <TileCaption
                     title='Shonda Rhimes'
+                    subtitle='Teaches Writing'
                     position='left bottom'
                   />
                   <Placeholder />
@@ -69,6 +72,7 @@ storiesOf('components|Tiles/TileCaption', module)
                 <Tile>
                   <TileCaption
                     title='Shonda Rhimes'
+                    subtitle='Teaches Writing'
                     position='center bottom'
                   />
                   <Placeholder />
@@ -76,13 +80,20 @@ storiesOf('components|Tiles/TileCaption', module)
               </div>
 
               <div className='col-sm-4'>
-                <Tile>
-                  <TileCaption
-                    title='Shonda Rhimes'
-                    position='left below'
-                  />
-                  <Placeholder />
-                </Tile>
+                <HoverHandler>
+                  {({ hovering }) =>
+                    <AnimationHandler type='zoom' animating={hovering}>
+                      <Tile>
+                        <TileCaption
+                          title='Shonda Rhimes'
+                          subtitle='Teaches Writing'
+                          position={hovering ? 'left below' : 'left bottom'}
+                        />
+                        <Placeholder />
+                      </Tile>
+                    </AnimationHandler>
+                  }
+                </HoverHandler>
               </div>
             </div>
           </PropExample>

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -80,23 +80,38 @@ storiesOf('components|Tiles/TileCaption', module)
               </div>
 
               <div className='col-sm-4'>
-                <HoverHandler>
-                  {({ hovering }) =>
-                    <AnimationHandler type='zoom' animating={hovering}>
-                      <Tile>
-                        <TileCaption
-                          title='Shonda Rhimes'
-                          subtitle='Teaches Writing'
-                          position={hovering ? 'left below' : 'left bottom'}
-                        />
-                        <Placeholder />
-                      </Tile>
-                    </AnimationHandler>
-                  }
-                </HoverHandler>
+                <Tile>
+                  <TileCaption
+                    title='Shonda Rhimes'
+                    subtitle='Teaches Writing'
+                    position='left below'
+                  />
+                  <Placeholder />
+                </Tile>
               </div>
             </div>
           </PropExample>
+        </DocSection>
+
+        <DocSection title='Example'>
+          <div className='row'>
+            <div className='col-sm-4'>
+              <HoverHandler>
+                {({ hovering }) =>
+                  <AnimationHandler type='zoom' animating={hovering}>
+                    <Tile>
+                      <TileCaption
+                        title='Shonda Rhimes'
+                        subtitle='Teaches Writing'
+                        position={hovering ? 'left below' : 'left bottom'}
+                      />
+                      <Placeholder />
+                    </Tile>
+                  </AnimationHandler>
+                }
+              </HoverHandler>
+            </div>
+          </div>
         </DocSection>
       </div>
     </div>

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -1,51 +1,92 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { withProps } from '../../utils/addon-props'
 
 import DocSection from '../../utils/DocSection'
 import PropExample from '../../utils/PropExample'
+import Placeholder from '../../utils/Placeholder'
 
 import Tile from '../Tile'
 import TileCaption from '../TileCaption'
 
 
 storiesOf('components|Tiles/TileCaption', module)
-  .add('TileCaption', () => (
+  .add('TileCaption', withProps(TileCaption)(() => (
     <div className='container'>
       <div className='container'>
         <h2>TileCaption</h2>
 
-        <DocSection title='Props'>
-          <div className='row'>
-            <div className='col-md-6'>
-                <PropExample
-                  name='title'
-                  type='String'
-                >
-                  <Tile>
-                    <TileCaption
-                      title='Shonda Rhimes'
-                    />
-                    <div className='example__filler' />
-                  </Tile>
-                </PropExample>
+        <DocSection title='Variants'>
+          <PropExample
+            name='title'
+            type='String'
+          >
+            <div className='row'>
+              <div className='col-sm-4'>
+                <Tile>
+                  <TileCaption
+                    title='Shonda Rhimes'
+                  />
+                  <Placeholder />
+                </Tile>
+              </div>
+            </div>
+          </PropExample>
+
+          <PropExample
+            name='subtitle'
+            type='String'
+          >
+            <div className='row'>
+              <div className='col-sm-4'>
+                <Tile>
+                  <TileCaption
+                    title='Shonda Rhimes'
+                    subtitle='Teaches Writing'
+                  />
+                  <Placeholder />
+                </Tile>
+              </div>
+            </div>
+          </PropExample>
+
+          <PropExample
+            name='position'
+            type='String'
+          >
+            <div className='row'>
+              <div className='col-sm-4'>
+                <Tile>
+                  <TileCaption
+                    title='Shonda Rhimes'
+                    position='left bottom'
+                  />
+                  <Placeholder />
+                </Tile>
               </div>
 
-              <div className='col-md-6'>
-                <PropExample
-                  name='subtitle'
-                  type='String'
-                >
-                  <Tile>
-                    <TileCaption
-                      title='Shonda Rhimes'
-                      subtitle='Teaches Writing'
-                    />
-                    <div className='example__filler' />
-                  </Tile>
-                </PropExample>
+              <div className='col-sm-4'>
+                <Tile>
+                  <TileCaption
+                    title='Shonda Rhimes'
+                    position='center bottom'
+                  />
+                  <Placeholder />
+                </Tile>
+              </div>
+
+              <div className='col-sm-4'>
+                <Tile>
+                  <TileCaption
+                    title='Shonda Rhimes'
+                    position='left below'
+                  />
+                  <Placeholder />
+                </Tile>
+              </div>
             </div>
-          </div>
+          </PropExample>
         </DocSection>
       </div>
     </div>
-  ))
+  )))

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -131,10 +131,29 @@
 
   &__titles {
     position: absolute;
-    left: 0;
-    bottom: 0;
-    margin: 16px;
+    padding: 16px;
+    width: 100%;
+    background: rgba($mc-dark, 0);
     text-shadow: 0 0 10px #000;
+    transition: transform 0.2s ease;
+
+    .mc-tile-caption--bottom & {
+      left: 0;
+      top: 100%;
+      transform: translateY(-100%);
+    }
+
+    .mc-tile-caption--below & {
+      left: 0;
+      top: 100%;
+      transform: translateY(0);
+      background: rgba($mc-dark, 1);
+      transition: transform 0.2s ease, background 0.2s ease 0.2s;
+    }
+
+    .mc-tile-caption--center & {
+      text-align: center;
+    }
   }
 
   &__title {


### PR DESCRIPTION
## Overview
Allows users to choose the text positioning easily with a prop.  Options will be, but not limited to:
- left bottom
- center bottom
- left below
- center below

```
<Tile>
  <TileCaption title="Someone" position="center bottom" />
  ...
</Tile>
```

![position](https://user-images.githubusercontent.com/249444/43505266-44f113a8-951b-11e8-8c70-c36f67af24dd.gif)


## Risks
None

## Changes
Adds the ability to change the position of the titles in TileCaption to handle more design use cases.  By default will be the same as it was (left bottom positioning).

## Issue
#13 #14 
