### PR TITLE
Fixing issue with PropsTable not reading more complex prop types

### DIFF
--- a/src/components/TextArea/index.js
+++ b/src/components/TextArea/index.js
@@ -10,6 +10,7 @@ export default class TextArea extends PureComponent {
     fullWidth: bool,
     resize: bool,
     style: object,
+    type: string,
     error: string,
   }
 

--- a/src/components/Tile/__snapshots__/index.stories.storyshot
+++ b/src/components/Tile/__snapshots__/index.stories.storyshot
@@ -216,7 +216,6 @@ exports[`Storyshots components|Tiles Summary 1`] = `
                     data-video-id="5450137526001"
                     loop={true}
                     muted={true}
-                    videoId="5450137526001"
                   />
                 </div>
               </div>

--- a/src/components/TileVideo/__snapshots__/index.stories.storyshot
+++ b/src/components/TileVideo/__snapshots__/index.stories.storyshot
@@ -90,7 +90,6 @@ exports[`Storyshots components|Tiles/TileVideo TileVideo 1`] = `
                           data-video-id="5450137526001"
                           loop={false}
                           muted={false}
-                          videoId="5450137526001"
                         />
                       </div>
                     </div>
@@ -171,7 +170,6 @@ exports[`Storyshots components|Tiles/TileVideo TileVideo 1`] = `
                           data-video-id="5450137526001"
                           loop={false}
                           muted={false}
-                          videoId="5450137526001"
                         />
                       </div>
                     </div>
@@ -252,7 +250,6 @@ exports[`Storyshots components|Tiles/TileVideo TileVideo 1`] = `
                           data-video-id="5450137526001"
                           loop={true}
                           muted={false}
-                          videoId="5450137526001"
                         />
                       </div>
                     </div>
@@ -333,7 +330,6 @@ exports[`Storyshots components|Tiles/TileVideo TileVideo 1`] = `
                           data-video-id="5450137526001"
                           loop={false}
                           muted={true}
-                          videoId="5450137526001"
                         />
                       </div>
                     </div>

--- a/src/components/TileVideo/index.js
+++ b/src/components/TileVideo/index.js
@@ -59,6 +59,7 @@ export default class TileVideo extends PureComponent {
       className,
       controls,
       videoId,
+      ...restProps
     } = this.props
 
     const {
@@ -94,7 +95,9 @@ export default class TileVideo extends PureComponent {
               data-video-id={videoId}
               data-player-id={PLAYER_ID}
               data-account={ACCOUNT_ID}
-              {...this.props}
+              controls={controls}
+              muted={muted}
+              {...restProps}
             />
 
             {children}

--- a/src/utils/PropsTable.js
+++ b/src/utils/PropsTable.js
@@ -1,4 +1,4 @@
-import { map, isEmpty } from 'lodash'
+import { map, isEmpty, isArray } from 'lodash'
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
@@ -28,8 +28,18 @@ styles.header = {
 }
 
 
+const formatName = (type) => {
+  if (type) {
+    return type.value && type.value.name
+      ? `${type.name}(${type.value.name})`
+      : type.name
+  }
+
+  return null
+}
+
 const formatOptions = (type) => {
-  if (type.value) {
+  if (type && isArray(type.value)) {
     return type.value.map(({ value, name }) => value || name).join(', ')
   }
 
@@ -69,7 +79,7 @@ export default class PropsTable extends PureComponent {
             <tr key={key} style={styles.row}>
               <th style={styles.header}>{key}</th>
               <td style={styles.cell} title={formatOptions(prop.type)}>
-                {prop.type.name}
+                {formatName(prop.type)}
               </td>
               <td style={styles.cell}>
                 {prop.required


### PR DESCRIPTION
## Overview
PropsTable wasn't considering non-primatives.  Now it _sorta_ handles them (does not support `shape` yet).  There is also a fix with TileVideo passing all props to the `<video>` element, causing a warning.

## Risks
Low

## Changes
n/a

## Issue
n/a
