### PR TITLE
Update package.json with correct path to styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
       "react-app"
     ]
   },
-  "style": "dist/styles/mc-components.css",
-  "sass": "src/styles/index.scss",
+  "style": "dist/styles/css/mc-components.css",
+  "sass": "dist/styles/scss/index.scss",
   "jest": {
     "moduleNameMapper": {
       "^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|ico)$": "<rootDir>/__mocks__/fileMock.js",


### PR DESCRIPTION
## Overview
Update name of compiled css file and path to file in package.json

## Risks
Medium (in case anyone is using the compiled css name, but unlikely since I checked the main MC repo already for imports, and the shorthand import wasn't working because the path was wrong)

## Changes
No visual change

## Issue
N/a
