### PR TITLE
Updating typography to not target direct elements

### DIFF
--- a/src/components/FoundationType/__snapshots__/index.stories.storyshot
+++ b/src/components/FoundationType/__snapshots__/index.stories.storyshot
@@ -61,7 +61,9 @@ exports[`Storyshots foundation|Type default 1`] = `
         <div
           className="col-md"
         >
-          <h1>
+          <h1
+            className="mc-heading-1"
+          >
             Unlock Every Class with the All‑Access Pass
           </h1>
         </div>
@@ -79,7 +81,9 @@ exports[`Storyshots foundation|Type default 1`] = `
         <div
           className="col-md"
         >
-          <h2>
+          <h2
+            className="mc-heading-2"
+          >
             Lorem Ipsum Sin Dolor
           </h2>
         </div>
@@ -97,7 +101,9 @@ exports[`Storyshots foundation|Type default 1`] = `
         <div
           className="col-md"
         >
-          <h3>
+          <h3
+            className="mc-heading-3"
+          >
             All-Access Pass
           </h3>
         </div>
@@ -115,7 +121,9 @@ exports[`Storyshots foundation|Type default 1`] = `
         <div
           className="col-md"
         >
-          <h4>
+          <h4
+            className="mc-heading-4"
+          >
             NOW AVAILABLE
           </h4>
         </div>
@@ -133,26 +141,8 @@ exports[`Storyshots foundation|Type default 1`] = `
         <div
           className="col-md"
         >
-          <p>
-            Online classes taught by the world's greatest minds. Now get unlimited access to all classes.
-          </p>
-        </div>
-      </div>
-      <div
-        className="row align-items-center"
-      >
-        <div
-          className="col-md-2 mc-type__description"
-        >
-          <p>
-            Body 2
-          </p>
-        </div>
-        <div
-          className="col-md"
-        >
           <p
-            className="mc-text-body-2"
+            className="mc-body"
           >
             Online classes taught by the world's greatest minds. Now get unlimited access to all classes.
           </p>
@@ -1377,7 +1367,36 @@ exports[`Storyshots foundation|Type default 1`] = `
                         &lt;
                         h1
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            className
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              "
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                mc-heading-1
+                              </span>
+                              "
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -1755,7 +1774,36 @@ exports[`Storyshots foundation|Type default 1`] = `
                         &lt;
                         h2
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            className
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              "
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                mc-heading-2
+                              </span>
+                              "
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -2133,7 +2181,36 @@ exports[`Storyshots foundation|Type default 1`] = `
                         &lt;
                         h3
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            className
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              "
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                mc-heading-3
+                              </span>
+                              "
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -2511,7 +2588,36 @@ exports[`Storyshots foundation|Type default 1`] = `
                         &lt;
                         h4
                       </span>
-                      <span />
+                      <span>
+                        <span>
+                           
+                          <span
+                            style={Object {}}
+                          >
+                            className
+                          </span>
+                          <span>
+                            =
+                            <span
+                              style={Object {}}
+                            >
+                              "
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                mc-heading-4
+                              </span>
+                              "
+                            </span>
+                          </span>
+                          
+                        </span>
+                      </span>
                       <span
                         style={
                           Object {
@@ -2889,384 +2995,6 @@ exports[`Storyshots foundation|Type default 1`] = `
                         &lt;
                         p
                       </span>
-                      <span />
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        &gt;
-                      </span>
-                    </div>
-                    <div
-                      style={
-                        Object {
-                          "paddingLeft": 78,
-                          "paddingRight": 3,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        Online classes taught by the world's greatest minds. Now get unlimited access to all classes.
-                      </span>
-                    </div>
-                    <div
-                      style={
-                        Object {
-                          "paddingLeft": 63,
-                          "paddingRight": 3,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        &lt;/
-                        p
-                        &gt;
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 48,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#777",
-                        }
-                      }
-                    >
-                      &lt;/
-                      div
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-                <div
-                  style={
-                    Object {
-                      "paddingLeft": 33,
-                      "paddingRight": 3,
-                    }
-                  }
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#777",
-                      }
-                    }
-                  >
-                    &lt;/
-                    div
-                    &gt;
-                  </span>
-                </div>
-              </div>
-              <div>
-                <div
-                  style={
-                    Object {
-                      "paddingLeft": 33,
-                      "paddingRight": 3,
-                    }
-                  }
-                >
-                  <span
-                    style={
-                      Object {
-                        "color": "#777",
-                      }
-                    }
-                  >
-                    &lt;
-                    div
-                  </span>
-                  <span>
-                    <span>
-                       
-                      <span
-                        style={Object {}}
-                      >
-                        className
-                      </span>
-                      <span>
-                        =
-                        <span
-                          style={Object {}}
-                        >
-                          "
-                          <span
-                            style={
-                              Object {
-                                "color": "#22a",
-                                "wordBreak": "break-word",
-                              }
-                            }
-                          >
-                            row align-items-center
-                          </span>
-                          "
-                        </span>
-                      </span>
-                      
-                    </span>
-                  </span>
-                  <span
-                    style={
-                      Object {
-                        "color": "#777",
-                      }
-                    }
-                  >
-                    &gt;
-                  </span>
-                </div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 48,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#777",
-                        }
-                      }
-                    >
-                      &lt;
-                      div
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          className
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            "
-                            <span
-                              style={
-                                Object {
-                                  "color": "#22a",
-                                  "wordBreak": "break-word",
-                                }
-                              }
-                            >
-                              col-md-2 mc-type__description
-                            </span>
-                            "
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#777",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div>
-                    <div
-                      style={
-                        Object {
-                          "paddingLeft": 63,
-                          "paddingRight": 3,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        &lt;
-                        p
-                      </span>
-                      <span />
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        &gt;
-                      </span>
-                    </div>
-                    <div
-                      style={
-                        Object {
-                          "paddingLeft": 78,
-                          "paddingRight": 3,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        Body 2
-                      </span>
-                    </div>
-                    <div
-                      style={
-                        Object {
-                          "paddingLeft": 63,
-                          "paddingRight": 3,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        &lt;/
-                        p
-                        &gt;
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 48,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#777",
-                        }
-                      }
-                    >
-                      &lt;/
-                      div
-                      &gt;
-                    </span>
-                  </div>
-                </div>
-                <div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 48,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#777",
-                        }
-                      }
-                    >
-                      &lt;
-                      div
-                    </span>
-                    <span>
-                      <span>
-                         
-                        <span
-                          style={Object {}}
-                        >
-                          className
-                        </span>
-                        <span>
-                          =
-                          <span
-                            style={Object {}}
-                          >
-                            "
-                            <span
-                              style={
-                                Object {
-                                  "color": "#22a",
-                                  "wordBreak": "break-word",
-                                }
-                              }
-                            >
-                              col-md
-                            </span>
-                            "
-                          </span>
-                        </span>
-                        
-                      </span>
-                    </span>
-                    <span
-                      style={
-                        Object {
-                          "color": "#777",
-                        }
-                      }
-                    >
-                      &gt;
-                    </span>
-                  </div>
-                  <div>
-                    <div
-                      style={
-                        Object {
-                          "paddingLeft": 63,
-                          "paddingRight": 3,
-                        }
-                      }
-                    >
-                      <span
-                        style={
-                          Object {
-                            "color": "#777",
-                          }
-                        }
-                      >
-                        &lt;
-                        p
-                      </span>
                       <span>
                         <span>
                            
@@ -3289,7 +3017,7 @@ exports[`Storyshots foundation|Type default 1`] = `
                                   }
                                 }
                               >
-                                mc-text-body-2
+                                mc-body
                               </span>
                               "
                             </span>

--- a/src/components/FoundationType/index.stories.js
+++ b/src/components/FoundationType/index.stories.js
@@ -33,7 +33,7 @@ storiesOf('foundation|Type', module)
           </div>
 
           <div className='col-md'>
-            <h1>Unlock Every Class with the All‑Access Pass</h1>
+            <h1 className='mc-heading-1'>Unlock Every Class with the All‑Access Pass</h1>
           </div>
         </div>
 
@@ -43,7 +43,7 @@ storiesOf('foundation|Type', module)
           </div>
 
           <div className='col-md'>
-            <h2>Lorem Ipsum Sin Dolor</h2>
+            <h2 className='mc-heading-2'>Lorem Ipsum Sin Dolor</h2>
           </div>
         </div>
 
@@ -53,7 +53,7 @@ storiesOf('foundation|Type', module)
           </div>
 
           <div className='col-md'>
-            <h3>All-Access Pass</h3>
+            <h3 className='mc-heading-3'>All-Access Pass</h3>
           </div>
         </div>
 
@@ -63,7 +63,7 @@ storiesOf('foundation|Type', module)
           </div>
 
           <div className='col-md'>
-            <h4>NOW AVAILABLE</h4>
+            <h4 className='mc-heading-4'>NOW AVAILABLE</h4>
           </div>
         </div>
 
@@ -73,19 +73,9 @@ storiesOf('foundation|Type', module)
           </div>
 
           <div className='col-md'>
-            <p>Online classes taught by the world&#39;s
+            <p className='mc-body'>Online classes taught by the world&#39;s
             greatest minds. Now get unlimited access to all classes.
             </p>
-          </div>
-        </div>
-
-        <div className='row align-items-center'>
-          <div className='col-md-2 mc-type__description'>
-            <p>Body 2</p>
-          </div>
-
-          <div className='col-md'>
-            <p className='mc-text-body-2'>Online classes taught by the world&#39;s greatest minds. Now get unlimited access to all classes.</p>
           </div>
         </div>
 

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -18,7 +18,7 @@ a {
   text-decoration: none;
 }
 
-h1 {
+.mc-heading-1 {
   font-size: 36px;
   line-height: 48px;
   letter-spacing: 0.04em;
@@ -26,14 +26,14 @@ h1 {
   color: #fff;
 }
 
-h2 {
+.mc-heading-2 {
   font-size: 32px;
   line-height: 44px;
   font-weight: 600;
   color: #fff;
 }
 
-h3 {
+.mc-heading-3 {
   font-size: 26px;
   line-height: 36px;
   letter-spacing: 0.06em;
@@ -41,7 +41,7 @@ h3 {
   color: #fff;
 }
 
-h4 {
+.mc-heading-4 {
   font-size: 18px;
   line-height: 36px;
   letter-spacing: 0.22em;
@@ -50,7 +50,7 @@ h4 {
   color: #fff;
 }
 
-p {
+.mc-body {
   font-size: 18px;
   line-height: 26px;
   letter-spacing: 0.025em;


### PR DESCRIPTION
## Overview
The typography styles target h1 - h6 and the paragraph tag, which leads to style conflicts when `mc-components` is imported into another codebase.  We should only use classes to specify heading and body styles.

## Risks
Low - I don't believe anywhere is relying on the styles in mc-components for type yet.

## Changes
No visual changes

## Issue
https://github.com/yankaindustries/mc-components/issues/133