### PR TITLE
Add font helper functionality like in bootstrap

### DIFF
--- a/src/components/Foundation/Type/index.stories.js
+++ b/src/components/Foundation/Type/index.stories.js
@@ -15,63 +15,63 @@ storiesOf('foundation|Type', module)
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Display 1</h5>
             <h1 className='mc-text-d1'>Malcolm Gladwell</h1>
-            <p className='mc-text--muted mc-text--code'>.mc-text-d1</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-d1</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Display 2</h5>
             <h1 className='mc-text-d2'>Teaches Writing</h1>
-            <p className='mc-text--muted mc-text--code'>.mc-text-d2</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-d2</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>H1</h5>
             <h1 className='mc-text-h1'>Unlock Every Class with the All‑Access Pass</h1>
-            <p className='mc-text--muted mc-text--code'>.mc-text-h1</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-h1</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>H2</h5>
             <h2 className='mc-text-h2'>All-Access Pass</h2>
-            <p className='mc-text--muted mc-text--code'>.mc-text-h2</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-h2</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>H3</h5>
             <h3 className='mc-text-h3'>Now Available</h3>
-            <p className='mc-text--muted mc-text--code'>.mc-text-h3</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-h3</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>H4</h5>
             <h4 className='mc-text-h4'>Diane Von Furstenburg</h4>
-            <p className='mc-text--muted mc-text--code'>.mc-text-h4</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-h4</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>H5</h5>
             <h5 className='mc-text-h5'>Teaches Fashion</h5>
-            <p className='mc-text--muted mc-text--code'>.mc-text-h5</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-h5</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Body</h5>
             <p>Online classes taught by the world&#39;s greatest minds. Now get
              unlimited access to all classes.</p>
-            <p className='mc-text--muted mc-text--code'>Default body text</p>
+            <p className='mc-text--muted mc-text--monospace'>Default body text</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Intro</h5>
             <p className='mc-text-intro'>Online classes taught by the world&#39;s greatest minds. Now get
              unlimited access to all classes.</p>
-            <p className='mc-text--muted mc-text--code'>.mc-text-intro</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-intro</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Legal</h5>
             <p className='mc-text-legal'>Copyright 2018 MasterClass</p>
-            <p className='mc-text--muted mc-text--code'>.mc-text-legal</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text-legal</p>
           </div>
         </div>
 
@@ -79,31 +79,31 @@ storiesOf('foundation|Type', module)
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Bold</h5>
             <p className='mc-text--bold'>The quick brown fox jumped over the lazy dog.</p>
-            <p className='mc-text--muted mc-text--code'>.mc-text--bold</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text--bold</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Uppercase</h5>
             <p className='mc-text--uppercase'>The quick brown fox jumped over the lazy dog.</p>
-            <p className='mc-text--muted mc-text--code'>.mc-text--uppercase</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text--uppercase</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Muted</h5>
             <p className='mc-text--muted'>The quick brown fox jumped over the lazy dog.</p>
-            <p className='mc-text--muted mc-text--code'>.mc-text--muted</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text--muted</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Combined Example</h5>
             <p className='mc-text--muted mc-text--uppercase mc-text --bold'>The quick brown fox jumped over the lazy dog.</p>
-            <p className='mc-text--muted mc-text--code'>.mc-text--muted.mc-text--uppercase.mc-text--bold</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text--muted.mc-text--uppercase.mc-text--bold</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Code</h5>
-            <p className='mc-text--code'>The quick brown fox jumped over the lazy dog.</p>
-            <p className='mc-text--muted mc-text--code'>.mc-text--code.mc-text--uppercase.mc-text--bold</p>
+            <p className='mc-text--monospace'>The quick brown fox jumped over the lazy dog.</p>
+            <p className='mc-text--muted mc-text--monospace'>.mc-text--monospace.mc-text--uppercase.mc-text--bold</p>
           </div>
         </div>
       </div>,

--- a/src/styles/libraries/_libraries.scss
+++ b/src/styles/libraries/_libraries.scss
@@ -3,19 +3,19 @@
 // Reset
 @import "reset";
 
-// Bootstrap Grid
+// MC Variables
 @import "../base/variables";
-@import "~bootstrap/scss/bootstrap-grid";
 
-// Bootstrap text helpers and dependencies
+// Bootstrap overrides
+@import "bootstrap-overrides/grid";
+
+// Bootstrap - the good parts
+@import "~bootstrap/scss/bootstrap-grid";
 @import "~bootstrap/scss/mixins/text-truncate";
 @import "~bootstrap/scss/mixins/text-emphasis";
 @import "~bootstrap/scss/mixins/hover";
 @import "~bootstrap/scss/mixins/text-hide";
 @import "~bootstrap/scss/utilities/text";
-
-// Our bootstrap overrides
-@import "bootstrap-overrides/grid";
 
 // Slick slider
 @import "node_modules/slick-carousel/slick/slick.scss";

--- a/src/styles/libraries/_libraries.scss
+++ b/src/styles/libraries/_libraries.scss
@@ -11,11 +11,6 @@
 
 // Bootstrap - the good parts
 @import "~bootstrap/scss/bootstrap-grid";
-@import "~bootstrap/scss/mixins/text-truncate";
-@import "~bootstrap/scss/mixins/text-emphasis";
-@import "~bootstrap/scss/mixins/hover";
-@import "~bootstrap/scss/mixins/text-hide";
-@import "~bootstrap/scss/utilities/text";
 
 // Slick slider
 @import "node_modules/slick-carousel/slick/slick.scss";

--- a/src/styles/libraries/_libraries.scss
+++ b/src/styles/libraries/_libraries.scss
@@ -5,6 +5,17 @@
 
 // Bootstrap Grid
 @import "../base/variables";
-@import "node_modules/bootstrap/scss/bootstrap-grid";
+@import "~bootstrap/scss/bootstrap-grid";
+
+// Bootstrap text helpers and dependencies
+@import "~bootstrap/scss/mixins/text-truncate";
+@import "~bootstrap/scss/mixins/text-emphasis";
+@import "~bootstrap/scss/mixins/hover";
+@import "~bootstrap/scss/mixins/text-hide";
+@import "~bootstrap/scss/utilities/text";
+
+// Our bootstrap overrides
 @import "bootstrap-overrides/grid";
+
+// Slick slider
 @import "node_modules/slick-carousel/slick/slick.scss";

--- a/src/styles/typography/modifiers.scss
+++ b/src/styles/typography/modifiers.scss
@@ -1,18 +1,43 @@
+// stylelint-disable declaration-no-important
 .mc-text {
+  // Monospaced
+  &--monospace {
+    font-family: monospace !important;
+  }
+
+  // Transformation
+  &--uppercase {
+    text-transform: uppercase !important;
+  }
+
+  &--lowercase {
+    text-transform: lowercase !important;
+  }
+
+  &--capitalize {
+    text-transform: capitalize !important;
+  }
+
+  // Weight / opacity
   &--bold {
-    font-weight: 600;
+    font-weight: 600 !important;
+  }
+
+  &--normal {
+    font-weight: 400 !important;
   }
 
   &--muted {
-    opacity: 0.5;
+    opacity: 0.5 !important;
   }
+}
 
-  &--uppercase {
-    text-transform: uppercase;
+// Responsive
+@each $breakpoint in map-keys($grid-breakpoints) {
+  @include media-breakpoint-up($breakpoint) {
+    $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+    .mc-text#{$infix}-left   { text-align: left !important; }
+    .mc-text#{$infix}-right  { text-align: right !important; }
+    .mc-text#{$infix}-center { text-align: center !important; }
   }
-
-  &--code {
-    font-family: monospace;
-  }
-
 }

--- a/src/styles/typography/modifiers.scss
+++ b/src/styles/typography/modifiers.scss
@@ -1,35 +1,17 @@
 // stylelint-disable declaration-no-important
 .mc-text {
   // Monospaced
-  &--monospace {
-    font-family: monospace !important;
-  }
+  &--monospace { font-family: monospace !important; }
 
   // Transformation
-  &--uppercase {
-    text-transform: uppercase !important;
-  }
-
-  &--lowercase {
-    text-transform: lowercase !important;
-  }
-
-  &--capitalize {
-    text-transform: capitalize !important;
-  }
+  &--uppercase { text-transform: uppercase !important; }
+  &--lowercase { text-transform: lowercase !important; }
+  &--capitalize { text-transform: capitalize !important; }
 
   // Weight / opacity
-  &--bold {
-    font-weight: 600 !important;
-  }
-
-  &--normal {
-    font-weight: 400 !important;
-  }
-
-  &--muted {
-    opacity: 0.5 !important;
-  }
+  &--bold { font-weight: 600 !important; }
+  &--normal { font-weight: 400 !important; }
+  &--muted { opacity: 0.5 !important; }
 }
 
 // Responsive

--- a/src/utils/CodeExample.js
+++ b/src/utils/CodeExample.js
@@ -34,7 +34,7 @@ export default class CodeExample extends PureComponent {
           {children}
         </div>
 
-        <div className='mc-text--code text-right'>
+        <div className='mc-text--monospace text-right'>
           <a onClick={this.toggleCode}>
             &lt;/&gt;
           </a>


### PR DESCRIPTION
## Overview
Adding in a few text helpers:

```
<p class="mc-text-uppercase">This text is uppercased</p>
<p class="mc-text-lowercase">This text is lowercased</p>
<p class="mc-text-capitalize">This text is capitalized</p>

<p class="mc-text-bold">This text is a normal font weight (400)</p>
<p class="mc-text-normal">This text is a bold font weight (700)</p>
<p class="mc-text-muted">This text is muted (50% opacity)</p>

<p class="mc-text-left">Left aligned text on all viewport sizes.</p>
<p class="mc-text-center">Center aligned text on all viewport sizes.</p>
<p class="mc-text-right">Right aligned text on all viewport sizes.</p>

<p class="mc-text-sm-left">Left aligned text on viewports sized SM (small) or wider.</p>
<p class="mc-text-md-left">Left aligned text on viewports sized MD (medium) or wider.</p>
<p class="mc-text-lg-left">Left aligned text on viewports sized LG (large) or wider.</p>
<p class="mc-text-xl-left">Left aligned text on viewports sized XL (extra-large) or wider.</p>
```

Idea borrowed from [bootstrap](https://getbootstrap.com/docs/4.0/utilities/text/).

## Risks
None

## Changes
Adds in new alignment functionality to text, and on a per-breakpoint level.

## Issue
N/A
