### PR TITLE
Clean up the easy JS lint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,9 @@
     "react/forbid-prop-types": 0,
     "function-paren-newline": 0,
     "no-shadow": 0,
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": 0,
+    "react/boolean-prop-naming": 0,
+    "react/jsx-handler-names": 0
   },
   "globals": {
     "window": true,

--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -16,6 +16,8 @@ const defaultSettings = {
 }
 
 export default class Carousel extends Component {
+  static Arrow = CarouselArrow;
+
   static propTypes = {
     slidesDataSource: PropTypes.arrayOf(PropTypes.shape({})),
     children: PropTypes.element,
@@ -32,8 +34,6 @@ export default class Carousel extends Component {
   static defaultProps = {
     hasArrows: true,
   }
-
-  static Arrow = CarouselArrow;
 
   handleNext = () => {
     this.slider.current.slickNext()

--- a/src/components/Foundation/Type/index.stories.js
+++ b/src/components/Foundation/Type/index.stories.js
@@ -57,14 +57,16 @@ storiesOf('foundation|Type', module)
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Body</h5>
             <p>Online classes taught by the world&#39;s greatest minds. Now get
-             unlimited access to all classes.</p>
+             unlimited access to all classes.
+            </p>
             <p className='mc-text--muted mc-text--monospace'>Default body text</p>
           </div>
 
           <div className='align-items-center example--section'>
             <h5 className='mc-text-h5'>Intro</h5>
             <p className='mc-text-intro'>Online classes taught by the world&#39;s greatest minds. Now get
-             unlimited access to all classes.</p>
+             unlimited access to all classes.
+            </p>
             <p className='mc-text--muted mc-text--monospace'>.mc-text-intro</p>
           </div>
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -29,7 +29,13 @@ export default class Modal extends Component {
     HeaderComponent: ModalHeader,
   }
 
-  container = React.createRef();
+  componentDidMount () {
+    document.addEventListener('keydown', this.onPressEsc)
+  }
+
+  componentWillUnmount () {
+    document.removeEventListener('keydown', this.onPressEsc)
+  }
 
   onClickOutside = () => {
     const { onClose, shouldCloseOnClickOutside } = this.props
@@ -47,13 +53,7 @@ export default class Modal extends Component {
     }
   }
 
-  componentDidMount () {
-    document.addEventListener('keydown', this.onPressEsc)
-  }
-
-  componentWillUnmount () {
-    document.removeEventListener('keydown', this.onPressEsc)
-  }
+  container = React.createRef();
 
   render () {
     const {

--- a/src/components/ModalPortal/index.js
+++ b/src/components/ModalPortal/index.js
@@ -7,8 +7,6 @@ export default class ModalPortal extends Component {
     children: oneOfType([arrayOf(node), node]).isRequired,
   }
 
-  el = document.createElement('div')
-
   componentDidMount () {
     const modalRoot = document.getElementById('modal-root')
     modalRoot.appendChild(this.el)
@@ -23,6 +21,8 @@ export default class ModalPortal extends Component {
     const body = document.getElementsByTagName('body')[0]
     body.classList.remove('modal__body--open')
   }
+
+  el = document.createElement('div')
 
   render () {
     return ReactDOM.createPortal(

--- a/src/components/RoundedBox/index.stories.js
+++ b/src/components/RoundedBox/index.stories.js
@@ -14,7 +14,8 @@ storiesOf('components|RoundedBox', module)
   .add('with header', withProps(RoundedBox)(() => (
     <RoundedBox
       header='Header'
-      subheader='Sub header'>
+      subheader='Sub header'
+    >
 
       <p>Content</p>
     </RoundedBox>


### PR DESCRIPTION
## Overview
I fixed the JS lint warnings that I was able to fix.  We went from 43 warnings to 8!

## Risks
None

## Changes
No visual changes, but removed the requirement in eslint for:
```
    "react/boolean-prop-naming": 0,
    "react/jsx-handler-names": 0
```

## Issue
https://github.com/yankaindustries/mc-components/issues/145