### PR TITLE
Make primary button style the default style

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -9,7 +9,6 @@ const Button = ({
   children,
   className,
   onClick,
-  primary,
   secondary,
   tertiary,
   fullWidth,
@@ -24,7 +23,6 @@ const Button = ({
     'c-button',
     { [className]: Boolean(className) },
     {
-      'c-button--primary': primary,
       'c-button--secondary': secondary,
       'c-button--tertiary': tertiary,
       'c-button--with-icon': Boolean(Icon),
@@ -59,7 +57,6 @@ Button.propTypes = {
   ]),
   className: string,
   onClick: func,
-  primary: bool,
   secondary: bool,
   tertiary: bool,
   fullWidth: bool,
@@ -73,7 +70,6 @@ Button.propTypes = {
 Button.defaultProps = {
   className: '',
   onClick: () => {},
-  primary: false,
   secondary: false,
   tertiary: false,
   fullWidth: false,

--- a/src/components/Button/index.stories.js
+++ b/src/components/Button/index.stories.js
@@ -35,16 +35,26 @@ const FacebookIcon = () => (
 storiesOf('components|Buttons', module)
   .add('Button', withProps(Button)(() => (
     <div className='container'>
-      <h2 className='mc-text-h2'>Button</h2>
+      <h2 className='mc-text-h2'>Button Types</h2>
 
       <DocSection title='Variations'>
         <PropExample
-          name='primary | secondary | tertiary | text'
+          name='default (no properties)'
+        >
+          <Button>Default</Button>
+        </PropExample>
+        <PropExample
+          name='secondary | tertiary'
           type='Boolean'
         >
-          <Button primary>Primary</Button>
           <Button secondary>Secondary</Button>
           <Button tertiary>Tertiary</Button>
+        </PropExample>
+
+        <PropExample
+          name='link | link muted | text'
+          type='Boolean'
+        >
           <Button link>Link</Button>
           <Button linkMuted>Link Muted</Button>
           <Button text>Text</Button>

--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -61,16 +61,6 @@
     }
   }
 
-  &--primary {
-    background-color: $mc-color-primary;
-
-    &:focus,
-    &.focus {
-      outline: 0;
-      box-shadow: 0 0 0 0.2rem rgba($mc-color-primary-hover, 0.25);
-    }
-  }
-
   &--secondary {
     background: $mc-color-secondary;
 

--- a/src/styles/components/buttons/_button.scss
+++ b/src/styles/components/buttons/_button.scss
@@ -1,5 +1,6 @@
 .c-button,
 .mc-c-btn {
+  background-color: $mc-color-primary;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -27,6 +28,7 @@
   &:focus,
   &.focus {
     outline: 0;
+    box-shadow: 0 0 0 0.2rem rgba($mc-color-primary-hover, 0.25);
   }
 
   // Disabled comes first so active can properly restyle


### PR DESCRIPTION
## Overview
The default button state (without properties) didn't look quite right, so let's make the primary button style the default style.

## Risks
Low - primary isn't used specifically in many places, but I've updated the component and checked in our repo for usage.  If a third party were using the primary class before, the default button would now have their desired styles.  A specific use case is in the masterclass repo here:
```
/app/views/accounts/_form.html.slim
```


## Changes
Visually no change, but default button component now uses primary styles

## Issue
https://github.com/yankaindustries/mc-components/issues/82