### PR TITLE
Sync header heights

### DIFF
--- a/src/components/HeaderLoggedIn/index.stories.js
+++ b/src/components/HeaderLoggedIn/index.stories.js
@@ -15,33 +15,78 @@ const menuLinks = [
 
 storiesOf('components|Structure/Header/LoggedIn', module)
   .add('default', withProps(HeaderLoggedIn)(() =>
-    <HeaderLoggedIn menuLinks={menuLinks} />,
+    <div>
+      <HeaderLoggedIn menuLinks={menuLinks} />
+      <div style={
+        {
+          paddingBottom: '2000px',
+          background: '#ccc',
+        }
+      }>
+      </div>
+    </div>,
   ))
   .add('minimal', withProps(HeaderLoggedIn)(() =>
-    <HeaderLoggedIn isMinimal />,
+    <div>
+      <HeaderLoggedIn isMinimal />
+      <div style={
+        {
+          paddingBottom: '2000px',
+          background: '#ccc',
+        }
+      }>
+      </div>
+    </div>,
   ))
   .add('with avatar', withProps(HeaderLoggedIn)(() => (
-    <HeaderLoggedIn
-      menuLinks={menuLinks}
-      avatar='https://graph.facebook.com/10156122473642900/picture?height=300&width=300'
-    />
+    <div>
+      <HeaderLoggedIn
+        menuLinks={menuLinks}
+        avatar='https://graph.facebook.com/10156122473642900/picture?height=300&width=300'
+      />
+      <div style={
+        {
+          paddingBottom: '2000px',
+          background: '#ccc',
+        }
+      }>
+      </div>
+    </div>
   )))
   .add('with badges', withProps(HeaderLoggedIn)(() => (
-    <HeaderLoggedIn
-      menuLinks={[
-        ...menuLinks,
-        { label: 'Profile', href: '/profile', badgeCount: 1 },
-        { label: 'Sign out', href: '/sign_out' },
-      ]}
-    />
+    <div>
+      <HeaderLoggedIn
+        menuLinks={[
+          ...menuLinks,
+          { label: 'Profile', href: '/profile', badgeCount: 1 },
+          { label: 'Sign out', href: '/sign_out' },
+        ]}
+      />
+      <div style={
+        {
+          paddingBottom: '2000px',
+          background: '#ccc',
+        }
+      }>
+      </div>
+    </div>
   )))
   .add('with backButton', withProps(HeaderLoggedIn)(() => (
-    <HeaderLoggedIn
-      menuLinks={menuLinks}
-      left={{
-        action: action('clicked'),
-        label: 'Back',
-        type: 'back',
-      }}
-    />
+    <div>
+      <HeaderLoggedIn
+        menuLinks={menuLinks}
+        left={{
+          action: action('clicked'),
+          label: 'Back',
+          type: 'back',
+        }}
+      />
+      <div style={
+        {
+          paddingBottom: '2000px',
+          background: '#ccc',
+        }
+      }>
+      </div>
+    </div>
   )))

--- a/src/components/HeaderLoggedOut/index.stories.js
+++ b/src/components/HeaderLoggedOut/index.stories.js
@@ -7,5 +7,14 @@ import HeaderLoggedOut from '../HeaderLoggedOut'
 
 storiesOf('components|Structure/Header/LoggedOut', module)
   .add('default', withProps(HeaderLoggedOut)(() =>
-    <HeaderLoggedOut />,
+    <div>
+      <HeaderLoggedOut />
+      <div style={
+        {
+          paddingBottom: '2000px',
+          background: '#ccc',
+        }
+      }>
+      </div>
+    </div>,
   ))

--- a/src/styles/components/_header-logged-out.scss
+++ b/src/styles/components/_header-logged-out.scss
@@ -80,7 +80,7 @@ $header-condensed-ease-timing: 450ms !default;
     &__logo {
       display: block;
       width: 124px;
-      height: 56px;
+      height: 54px;
       margin: 0 auto;
       transition: margin $header-condensed-ease-timing ease;
       color: $mc-light;
@@ -128,12 +128,12 @@ $header-condensed-ease-timing: 450ms !default;
       }
 
       .header-logged-out__logo {
-        margin-top: -45px;
+        margin-top: -43px;
         transition: margin $header-condensed-ease-timing ease;
       }
 
       .header-logged-out__nav {
-        padding: 11.5px;
+        padding: 12px;
       }
     }
   }

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -31,9 +31,9 @@
     background: transparent;
     text-decoration: none;
     display: block;
-    width: 130px;
-    height: 14px;
-    margin: 10px auto;
+    width: 124px;
+    height: 16px;
+    margin: 9px auto;
     color: $mc-light;
 
     svg {


### PR DESCRIPTION
## Overview
Get the logged in and logged out heights to be the same.

## Risks
Medium - the header heights are finicky but we aren't using the new header anywhere yet in the masterclass repo.

## Changes
Visually subtle changes - height of both logged in and logged out headers are now the same.

## Issue
First step of: https://github.com/yankaindustries/mc-components/issues/157