### PR TITLE
Fix dependency path for bootstrap

### DIFF
--- a/src/styles/libraries/_libraries.scss
+++ b/src/styles/libraries/_libraries.scss
@@ -7,7 +7,7 @@
 @import "../base/variables";
 
 // Bootstrap - the good parts
-@import "~bootstrap/scss/bootstrap-grid";
+@import "node_modules/bootstrap/scss/bootstrap-grid";
 
 // Bootstrap overrides
 @import "bootstrap-overrides/grid";


### PR DESCRIPTION
Bootstrap dependency path isn't working correctly, re-reference node_modules for now.

`~bootstrap/` and `bootstrap/` did not work :/