### PR TITLE
Remove font

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Our components do **not** contain any styles.  The style library must also be im
 @import 'mc-components';
 ```
 
+### Font files
+We use Lato as our primary font for headings and body text in 300, 400, and 700 font weights.  You can import it in your css below, or import it into your asset pipeline.
+```
+@import url("https://fonts.googleapis.com/css?family=Lato:300,400,700");
+```
+
 ### Standalone style usage
 If your project doesn't use yarn or npm for dependencies and you're only looking for masterclass css / style files, they can be imported manually by downloading the repository on github.  This will give you access to styles for buttons, the grid, typography, and more.  Save the contents of the `/dist/styles/scss/` folder to your own project, then import!
 

--- a/src/styles/typography/_typography.scss
+++ b/src/styles/typography/_typography.scss
@@ -1,3 +1,2 @@
-@import "fonts";
 @import "base";
 @import "modifiers";

--- a/src/styles/typography/fonts.scss
+++ b/src/styles/typography/fonts.scss
@@ -1,3 +1,0 @@
-// Eventually consider moving this
-// into the build system?
-@import url("https://fonts.googleapis.com/css?family=Lato:300,400,700");


### PR DESCRIPTION
## Overview
We're importing the font multiple times in the main repo. We'll remove it from mc-components as a direct import and let consumers know that they need to manually import the font.

## Risks
Low

## Changes
Visually removes font family, relies on it being imported manually now.

## Issue
https://github.com/yankaindustries/mc-components/issues/163