### PR TITLE
Define color variables for body background and text colors

### DIFF
--- a/.storybook/_upside-down.scss
+++ b/.storybook/_upside-down.scss
@@ -53,7 +53,7 @@
 }
 
 body {
-  background: $mc-background;
+  background: $mc-color-background;
 }
 
 pre {

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -6,6 +6,11 @@
 // Fonts
 $mc-font-default: "Lato", "Helvetica", "Arial", sans-serif !default; // Should be used in most cases
 
+// If we move to a light site later
+// these variables will be easier to find
+$mc-light:                   #fff !default;
+$mc-dark:                    #000 !default;
+
 // Colors
 $mc-color-primary:           #c83232 !default;
 $mc-color-primary-hover:     #d63636 !default;
@@ -20,15 +25,8 @@ $mc-color-tertiary-hover:    #90949d !default;
 
 $mc-color-background:        #090909 !default;
 $mc-color-background-invert: #ebeeee !default;
-$mc-color-text:              #272c33 !default;
+$mc-color-text:              $mc-light !default;
 $mc-color-text-invert:       #8ca1c1 !default;
-
-
-// If we move to a light site later
-// these variables will be easier to find
-$mc-light:                   #fff !default;
-$mc-dark:                    #000 !default;
-
 
 // Not quite 50 of them, but...
 $mc-gray-100:           #333 !default;

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -18,11 +18,17 @@ $mc-color-secondary-active:  #1f1f21 !default;
 $mc-color-tertiary:          #75787f !default;
 $mc-color-tertiary-hover:    #90949d !default;
 
+$mc-color-background:        #090909 !default;
+$mc-color-background-invert: #ebeeee !default;
+$mc-color-text:              #272c33 !default;
+$mc-color-text-invert:       #8ca1c1 !default;
+
+
 // If we move to a light site later
 // these variables will be easier to find
 $mc-light:                   #fff !default;
 $mc-dark:                    #000 !default;
-$mc-background:              #090909 !default;
+
 
 // Not quite 50 of them, but...
 $mc-gray-100:           #333 !default;

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -3,6 +3,7 @@ html {
 }
 
 body {
+  background: $mc-color-background;
   font-family: $mc-font-default;
   font-size: 15px;
   line-height: 1.5;

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -8,7 +8,7 @@ body {
   font-size: 15px;
   line-height: 1.5;
   font-weight: 400;
-  color: $mc-light;
+  color: $mc-color-text;
   letter-spacing: 0.015em;
   font-variant-ligatures: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
Defines color variables for background, text color, and sets them on body

## Overview
Adds new variables: 
```
$mc-color-background:        #090909 !default;
$mc-color-background-invert: #ebeeee !default;
$mc-color-text:              #272c33 !default;
$mc-color-text-invert:       #8ca1c1 !default;
```

And sets them by default on body - now when you import mc-components' styles into a page, you'll get the black background and white text by default.

## Risks
None - checked mc repo and mc-components for variable use and does not exist.

## Changes
N/A

## Issue
https://github.com/yankaindustries/mc-components/issues/183