### PR TITLE
Consolidate heading type styles

### DIFF
--- a/src/foundation/type/index.stories.js
+++ b/src/foundation/type/index.stories.js
@@ -22,6 +22,12 @@ storiesOf('foundation|Type', module)
         </div>
 
         <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Display 3</h5>
+          <h1 className='mc-text-d3'>Now Available</h1>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text-d3</p>
+        </div>
+
+        <div className='align-items-center example--section'>
           <h5 className='mc-text-h5'>H1</h5>
           <h1 className='mc-text-h1'>Unlock Every Class with the All‑Access Pass</h1>
           <p className='mc-text--muted mc-text--monospace'>.mc-text-h1</p>
@@ -52,11 +58,11 @@ storiesOf('foundation|Type', module)
         </div>
 
         <div className='align-items-center example--section'>
-          <h5 className='mc-text-h5'>Body</h5>
+          <h5 className='mc-text-h5'>Default body text</h5>
           <p>Online classes taught by the world&#39;s greatest minds. Now get
            unlimited access to all classes.
           </p>
-          <p className='mc-text--muted mc-text--monospace'>Default body text</p>
+          <p className='mc-text--muted mc-text--monospace'>&lt;p&gt; - No class needed</p>
         </div>
 
         <div className='align-items-center example--section'>
@@ -82,13 +88,7 @@ storiesOf('foundation|Type', module)
         <p className='mc-text-p'>All available text modifier classes.</p>
       </div>
 
-      <div className='container example--section'>
-        <div className='align-items-center example--section'>
-          <h5 className='mc-text-h5'>Monospace</h5>
-          <p className='mc-text--monospace'>The quick brown fox jumped over the lazy dog.</p>
-          <p className='mc-text--muted mc-text--monospace'>.mc-text--monospace.mc-text--uppercase.mc-text--bold</p>
-        </div>
-
+      <div className='container'>
         <div className='align-items-center example--section'>
           <h5 className='mc-text-h5'>Uppercase</h5>
           <p className='mc-text--uppercase'>The quick brown fox jumped over the lazy dog.</p>
@@ -108,13 +108,13 @@ storiesOf('foundation|Type', module)
         </div>
 
         <div className='align-items-center example--section'>
-          <h5 className='mc-text-h5'>Bold</h5>
+          <h5 className='mc-text-h5'>Font weight - Bold</h5>
           <p className='mc-text--bold'>The quick brown fox jumped over the lazy dog.</p>
           <p className='mc-text--muted mc-text--monospace'>.mc-text--bold</p>
         </div>
 
         <div className='align-items-center example--section'>
-          <h5 className='mc-text-h5'>Normal</h5>
+          <h5 className='mc-text-h5'>Font weight - Normal</h5>
           <h1 className='mc-text-h1 mc-text--normal'>The quick brown fox jumped over the lazy dog.</h1>
           <p className='mc-text--muted mc-text--monospace'>.mc-text--h1.mc-text--normal</p>
         </div>
@@ -126,11 +126,29 @@ storiesOf('foundation|Type', module)
         </div>
 
         <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Airy</h5>
+          <p className='mc-text--airy'>The quick brown fox jumped over the lazy dog.</p>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text--airy</p>
+        </div>
+
+        <div className='align-items-center example--section'>
           <h5 className='mc-text-h5'>Invert</h5>
           <div className='rounded-box'>
             <p className='mc-text--invert'>The quick brown fox jumped over the lazy dog.</p>
           </div>
           <p className='mc-text--muted mc-text--monospace'>.mc-text--invert</p>
+        </div>
+
+        <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Monospace</h5>
+          <p className='mc-text--monospace'>The quick brown fox jumped over the lazy dog.</p>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text--monospace.mc-text--uppercase.mc-text--bold</p>
+        </div>
+
+        <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Chaining modifiers</h5>
+          <p className='mc-text--uppercase mc-text--airy mc-text--bold'>The quick brown fox jumped over the lazy dog.</p>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text--uppercase.mc-text--airy.mc-text--bold</p>
         </div>
       </div>
     </div>,
@@ -165,12 +183,6 @@ storiesOf('foundation|Type', module)
           <h5 className='mc-text-h5'>Responsive alignment</h5>
           <p className='mc-text-right mc-text-md-center'>The quick brown fox jumped over the lazy dog.</p>
           <p className='mc-text--muted mc-text--monospace'>.mc-text-right mc-text-md-center</p>
-        </div>
-
-        <div className='align-items-center example--section'>
-          <h5 className='mc-text-h5'>Chaining modifiers</h5>
-          <p className='mc-text--muted mc-text--uppercase mc-text --bold'>The quick brown fox jumped over the lazy dog.</p>
-          <p className='mc-text--muted mc-text--monospace'>.mc-text--muted.mc-text--uppercase.mc-text--bold</p>
         </div>
       </div>
     </div>,
@@ -213,6 +225,7 @@ storiesOf('foundation|Type', module)
               <p className='mc-text-hr'><span>Yeah!</span></p>
             </div>
           </div>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text-hr</p>
         </div>
 
         <div className='align-items-center example--section'>
@@ -230,6 +243,31 @@ storiesOf('foundation|Type', module)
               </div>
             </div>
           </div>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text-hr</p>
+        </div>
+      </div>
+    </div>,
+  )
+  .add('Colors', () =>
+    <div className='example-mc-type'>
+      <div className='container example--section'>
+        <h2 className='mc-text-d1'>Color Treatments</h2>
+        <p className='mc-text-p'>For specific branding guideline requirements.</p>
+      </div>
+
+      <div className='container example--section'>
+        <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Align left</h5>
+          <p className='mc-text--facebook'>Facebook brand color</p>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text-facebook</p>
+        </div>
+      </div>
+
+      <div className='container example--section'>
+        <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Align left</h5>
+          <p className='mc-text--twitter'>Twitter brand color</p>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text-twitter</p>
         </div>
       </div>
     </div>,

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -32,6 +32,14 @@ a { text-decoration: none; }
   text-transform: uppercase;
 }
 
+.mc-text-d3 {
+  font-size: 20px;
+  letter-spacing: 0.24em;
+  font-weight: 700;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
 // html header equivalents
 .mc-text-h1,
 .mc-text-h2,
@@ -40,36 +48,27 @@ a { text-decoration: none; }
 .mc-text-h5 {
   font-weight: 700;
   line-height: 1.25;
+  letter-spacing: 0.04em;
 }
 
 .mc-text-h1 {
   font-size: 32px;
-  letter-spacing: 0.04em;
 }
 
 .mc-text-h2 {
   font-size: 24px;
-  letter-spacing: 0.06em;
 }
 
 .mc-text-h3 {
   font-size: 20px;
-  letter-spacing: 0.24em;
-  font-weight: 400;
-  text-transform: uppercase;
 }
 
 .mc-text-h4 {
   font-size: 16px;
-  letter-spacing: 0.06em;
-  font-weight: 400;
-  text-transform: uppercase;
 }
 
 .mc-text-h5 {
   font-size: 12px;
-  letter-spacing: 0.17em;
-  text-transform: uppercase;
 }
 
 .mc-text-intro {

--- a/src/styles/typography/modifiers.scss
+++ b/src/styles/typography/modifiers.scss
@@ -1,8 +1,5 @@
 // stylelint-disable declaration-no-important
 .mc-text {
-  // Monospaced
-  &--monospace { font-family: monospace !important; }
-
   // Transformation
   &--uppercase { text-transform: uppercase !important; }
   &--lowercase { text-transform: lowercase !important; }
@@ -13,10 +10,16 @@
   &--normal { font-weight: 400 !important; }
   &--muted { opacity: 0.5 !important; }
 
+  // Treatments
+  &--airy { letter-spacing: 0.24em; }
+
   // Colors
   &--invert { color: $mc-dark; }
   &--twitter { color: #1da1f2; }
   &--facebook { color: #3b5998; }
+
+  // Monospaced
+  &--monospace { font-family: monospace !important; }
 }
 
 // Responsive


### PR DESCRIPTION
## Overview
Consolidate heading styles for a standardized h1-h5 and display 1-3

## Risks
Low - verified there is only one place we currently use `mc-text-h2` in the main repo, will shift text slightly (letter spacing change) but is not a dealbreaker.

## Changes
Minor visual changes to one location where h2 is currently being used, but that shift is ok to consolidate type styles.

## Issue
https://github.com/yankaindustries/mc-components/issues/182