### PR TITLE
Adding responsive typography per design comp

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -49,15 +49,6 @@ $yiq-text-light:            #fff !default;
 // Animations
 $mc-default-ease: cubic-bezier(0.25, 0.1, 0.25, 1) !default;
 
-// Breakpoints
-$mc-bp-xs:     0 !default;
-$mc-bp-sm:     576px !default;
-$mc-bp-md:     768px !default;
-$mc-bp-lg:     992px !default;
-$mc-bp-xl:     1200px !default;
-// NOTE: If we change these breakpoint values, we
-// also need to update them for ResponsiveHandler.
-
 // Z-indexes
 $mc-zindex-dropdown:          1000 !default;
 $mc-zindex-sticky:            1020 !default;
@@ -96,6 +87,15 @@ $transition-base:        all 0.2s ease-in-out !default;
 // Custom bootstrap grid overrides
 $grid-gutter-width:      16px !default;
 $grid-gutter-xl-width:   32px !default;
+
+// Breakpoints
+$mc-bp-xs:     0 !default;
+$mc-bp-sm:     576px !default;
+$mc-bp-md:     768px !default;
+$mc-bp-lg:     992px !default;
+$mc-bp-xl:     1200px !default;
+// NOTE: If we change these breakpoint values, we
+// also need to update them for ResponsiveHandler.
 
 $grid-breakpoints: (
   xs: $mc-bp-xs,

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -2,10 +2,11 @@ html {
   font-size: 62.5%;
 }
 
+// Referenced as "paragraph 2" in comps
 body {
   background: $mc-color-background;
   font-family: $mc-font-default;
-  font-size: 15px;
+  font-size: 12px;
   line-height: 1.5;
   font-weight: 400;
   color: $mc-color-text;
@@ -20,20 +21,20 @@ a { text-decoration: none; }
 
 // Big "display" text
 .mc-text-d1 {
-  font-size: 48px;
+  font-size: 24px;
   letter-spacing: 0.04em;
   font-weight: 700;
 }
 
 .mc-text-d2 {
-  font-size: 32px;
+  font-size: 20px;
   letter-spacing: 0.06em;
   font-weight: 400;
   text-transform: uppercase;
 }
 
 .mc-text-d3 {
-  font-size: 20px;
+  font-size: 16px;
   letter-spacing: 0.24em;
   font-weight: 700;
   line-height: 1.25;
@@ -52,35 +53,60 @@ a { text-decoration: none; }
 }
 
 .mc-text-h1 {
-  font-size: 32px;
-}
-
-.mc-text-h2 {
-  font-size: 24px;
-}
-
-.mc-text-h3 {
   font-size: 20px;
 }
 
-.mc-text-h4 {
+.mc-text-h2 {
   font-size: 16px;
+}
+
+.mc-text-h3 {
+  font-size: 16px;
+}
+
+.mc-text-h4 {
+  font-size: 12px;
 }
 
 .mc-text-h5 {
   font-size: 12px;
 }
 
+// Referenced as "paragraph 1" in comps
 .mc-text-intro {
-  font-size: 18px;
+  font-size: 16px;
   line-height: 26px;
   letter-spacing: 0.025em;
   font-weight: 400;
 }
 
 .mc-text-legal {
-  font-size: 11px;
+  font-size: 12px;
   line-height: 18px;
   letter-spacing: 0.5px;
   font-weight: 400;
+}
+
+// responsive
+@media (min-width: $mc-bp-sm) {
+  body { font-size: 16px; }
+
+  .mc-text-d1 { font-size: 32px; }
+  .mc-text-d2 { font-size: 24px; }
+
+  .mc-text-h1 { font-size: 24px; }
+  .mc-text-h2 { font-size: 20px; }
+  .mc-text-h4 { font-size: 16px; }
+
+  .mc-text-intro { font-size: 20px; }
+}
+
+@media (min-width: $mc-bp-lg) {
+  .mc-text-d1 { font-size: 48px; }
+  .mc-text-d2 { font-size: 32px; }
+  .mc-text-d3 { font-size: 20px; }
+
+  .mc-text-h1 { font-size: 32px; }
+  .mc-text-h2 { font-size: 24px; }
+  .mc-text-h3 { font-size: 20px; }
 }


### PR DESCRIPTION
## Overview
Resize text elements based on viewport width.  These values will most likely change, but add in support to easily update as the design comp becomes more finalized.

## Risks
Low - this will most likely visually affect our components as we tweak the font sizes with design.  We are ok with visual changes due to these updates.

## Changes
- Default body font got a slight size bump
- Text default is from 0 - "small" (576px)
- Next breakpoint is from "small" (576) - "large" (992px)
- Last breakpoint (biggest text) is from "large" (992px) and up.

## Issue
https://github.com/yankaindustries/mc-components/issues/178