### PR TITLE
Tile improvements

### DIFF
--- a/src/components/AnimationHandler/index.stories.js
+++ b/src/components/AnimationHandler/index.stories.js
@@ -72,11 +72,14 @@ storiesOf('utilities|AnimationHandler', module)
                   <TileOverlay type='gradient-bottom' />
 
                   <AnimationHandler type='lift' animating={hovering}>
-                    <TileCaption
-                      title='Shonda Rhimes'
-                      subtitle='Teaches Writing for Television'
-                      backdrop
-                    />
+                    <TileCaption>
+                      <h2 className='mc-text-h2 mc-text--uppercase'>
+                        Shonda Rhimes
+                      </h2>
+                      <h4 className='mc-text-h4 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                        Teaches Writing for Television
+                      </h4>
+                    </TileCaption>
                   </AnimationHandler>
                 </Tile>
               }

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -16,6 +16,7 @@ export default class Background extends PureComponent {
       PropTypes.node,
     ]).isRequired,
     fit: PropTypes.oneOf([
+      'container',
       'content',
       'background',
     ]),

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -84,10 +84,14 @@ storiesOf('components|Carousel', module)
                 <Tile key={item.id}>
                   <TileImage imageUrl={item.thumbnail} />
                   <TileOverlay />
-                  <TileCaption
-                    title={item.instructor}
-                    subtitle={`Teaches ${item.teaches}`}
-                  />
+                  <TileCaption>
+                    <h3 className='mc-text-h4 mc-text--uppercase'>
+                      {item.instructor}
+                    </h3>
+                    <h5 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                      {`Teaches ${item.teaches}`}
+                    </h5>
+                  </TileCaption>
                 </Tile>
               </div>
             ))}

--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -46,10 +46,14 @@ storiesOf('components|Tiles', module)
           <div className='col-lg-4 col-md-6'>
             <DocSection title='TileCaption'>
               <Tile>
-                <TileCaption
-                  title='Shonda Rhimes'
-                  subtitle='Teaches Writing'
-                />
+                <TileCaption>
+                  <h3 className='mc-text-h4 mc-text--uppercase'>
+                    Shonda Rhimes
+                  </h3>
+                  <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                    Teaches Writing
+                  </h4>
+                </TileCaption>
                 <Placeholder />
               </Tile>
             </DocSection>
@@ -105,10 +109,14 @@ storiesOf('components|Tiles', module)
                             type='lift'
                             animating={hovering}
                           >
-                            <TileCaption
-                              title='Shonda Rhimes'
-                              subtitle='Teaches Writing'
-                            />
+                            <TileCaption>
+                              <h3 className='mc-text-h4 mc-text--uppercase'>
+                                Shonda Rhimes
+                              </h3>
+                              <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                                Teaches Writing
+                              </h4>
+                            </TileCaption>
                           </AnimationHandler>
                         </Fragment>
                       }
@@ -132,20 +140,32 @@ storiesOf('components|Tiles', module)
                         <Fragment>
                           <TileImage imageUrl={shondaRhimesThumbnail} />
                           <TileOverlay type='gradient-bottom' />
-                          <TileCaption
-                            title='Shonda Rhimes'
-                            subtitle='Teaches Writing'
-                          />
                         </Fragment>
                       }
                       {hovering &&
-                        <TileVideo
-                          videoId='5450137526001'
-                          autoPlay
-                          loop
-                          muted
-                        />
+                        <Fragment>
+                          <TileVideo
+                            videoId='5450137526001'
+                            autoPlay
+                            loop
+                            muted
+                          />
+                        </Fragment>
                       }
+
+                      <TileCaption
+                        position={hovering
+                          ? 'left below'
+                          : 'left bottom'
+                        }
+                      >
+                        <h3 className='mc-text-h4 mc-text--uppercase'>
+                          Shonda Rhimes
+                        </h3>
+                        <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                          Teaches Writing
+                        </h4>
+                      </TileCaption>
                     </Tile>
                   </AnimationHandler>
                 }
@@ -164,10 +184,10 @@ storiesOf('components|Tiles/Tile', module)
       <div className='container'>
         <h2 className='mc-text-h2'>Tile</h2>
 
-        <DocSection title='Props'>
+        <DocSection title='Variations'>
           <PropExample
             name='aspectRatio'
-            type='String[16x9]'
+            type='String'
           >
             <div className='row'>
               <div className='col-sm-4'>
@@ -175,28 +195,51 @@ storiesOf('components|Tiles/Tile', module)
                   <Placeholder>16x9</Placeholder>
                 </Tile>
               </div>
-
               <div className='col-sm-4'>
+                <Tile aspectRatio='16x9'>
+                  <Placeholder>16x9</Placeholder>
+                </Tile>
+              </div>
+              <div className='col-sm-4'>
+                <Tile aspectRatio='16x9'>
+                  <Placeholder>16x9</Placeholder>
+                </Tile>
+              </div>
+
+              <div className='col-sm-12'>
+                <Tile aspectRatio='519x187'>
+                  <Placeholder>519x187</Placeholder>
+                </Tile>
+              </div>
+
+              <div className='col-sm-2'>
                 <Tile aspectRatio='4x3'>
                   <Placeholder>4x3</Placeholder>
                 </Tile>
               </div>
-
-              <div className='col-sm-4'>
-                <Tile aspectRatio='100x65'>
-                  <Placeholder>100x65</Placeholder>
+              <div className='col-sm-2'>
+                <Tile aspectRatio='4x3'>
+                  <Placeholder>4x3</Placeholder>
                 </Tile>
               </div>
-
-              <div className='col-sm-4'>
-                <Tile aspectRatio='1000x609'>
-                  <Placeholder>1000x609</Placeholder>
+              <div className='col-sm-2'>
+                <Tile aspectRatio='4x3'>
+                  <Placeholder>4x3</Placeholder>
                 </Tile>
               </div>
-
-              <div className='col-sm-4'>
-                <Tile aspectRatio='519x187'>
-                  <Placeholder>519x187</Placeholder>
+              <div className='col-sm-2'>
+                <Tile aspectRatio='4x3'>
+                  <Placeholder>4x3</Placeholder>
+                </Tile>
+              </div>
+              <div className='col-sm-2'>
+                <Tile aspectRatio='4x3'>
+                  <Placeholder>4x3</Placeholder>
+                </Tile>
+              </div>
+              <div className='col-sm-2'>
+                <Tile aspectRatio='4x3'>
+                  <Placeholder>4x3</Placeholder>
                 </Tile>
               </div>
             </div>

--- a/src/components/TileCaption/index.js
+++ b/src/components/TileCaption/index.js
@@ -4,7 +4,10 @@ import PropTypes from 'prop-types'
 
 export default class TileCaption extends PureComponent {
   static propTypes = {
-    children: PropTypes.element,
+    children: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.arrayOf(PropTypes.node),
+    ]),
     className: PropTypes.string,
     position: PropTypes.oneOf([
       'left bottom',
@@ -12,8 +15,6 @@ export default class TileCaption extends PureComponent {
       'left below',
       'center below',
     ]),
-    subtitle: PropTypes.string,
-    title: PropTypes.string,
   }
 
   static defaultProps = {
@@ -25,8 +26,6 @@ export default class TileCaption extends PureComponent {
       children,
       className,
       position,
-      subtitle,
-      title,
     } = this.props
 
     const positionClasses =
@@ -41,21 +40,8 @@ export default class TileCaption extends PureComponent {
 
     return (
       <div className={classes}>
-        <div className='mc-tile-caption__titles'>
-          {title &&
-            <h4 className='mc-tile-caption__title mc-text-h2 mc-text--uppercase'>
-              {title}
-            </h4>
-          }
-          {subtitle &&
-            <h5 className='mc-tile-caption__subtitle mc-text-h4 mc-text--muted'>
-              {subtitle}
-            </h5>
-          }
-        </div>
-
         {children &&
-          <div className='mc-tile-caption__content content'>
+          <div className='mc-tile-caption__content'>
             {children}
           </div>
         }

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -8,8 +8,6 @@ import Placeholder from '../../utils/Placeholder'
 
 import Tile from '../Tile'
 import TileCaption from '../TileCaption'
-import AnimationHandler from '../AnimationHandler'
-import HoverHandler from '../HoverHandler'
 
 
 storiesOf('components|Tiles/TileCaption', module)
@@ -20,98 +18,38 @@ storiesOf('components|Tiles/TileCaption', module)
 
         <DocSection title='Variants'>
           <PropExample
-            name='title'
-            type='String'
-          >
-            <div className='row'>
-              <div className='col-sm-4'>
-                <Tile>
-                  <TileCaption
-                    title='Shonda Rhimes'
-                  />
-                  <Placeholder />
-                </Tile>
-              </div>
-            </div>
-          </PropExample>
-
-          <PropExample
-            name='subtitle'
-            type='String'
-          >
-            <div className='row'>
-              <div className='col-sm-4'>
-                <Tile>
-                  <TileCaption
-                    title='Shonda Rhimes'
-                    subtitle='Teaches Writing'
-                  />
-                  <Placeholder />
-                </Tile>
-              </div>
-            </div>
-          </PropExample>
-
-          <PropExample
             name='position'
             type='String'
           >
             <div className='row'>
               <div className='col-sm-4'>
                 <Tile>
-                  <TileCaption
-                    title='Shonda Rhimes'
-                    subtitle='Teaches Writing'
-                    position='left bottom'
-                  />
+                  <TileCaption position='left bottom'>
+                    left bottom
+                  </TileCaption>
                   <Placeholder />
                 </Tile>
               </div>
 
               <div className='col-sm-4'>
                 <Tile>
-                  <TileCaption
-                    title='Shonda Rhimes'
-                    subtitle='Teaches Writing'
-                    position='center bottom'
-                  />
+                  <TileCaption position='center bottom'>
+                    center bottom
+                  </TileCaption>
                   <Placeholder />
                 </Tile>
               </div>
 
               <div className='col-sm-4'>
                 <Tile>
-                  <TileCaption
-                    title='Shonda Rhimes'
-                    subtitle='Teaches Writing'
-                    position='left below'
-                  />
+                  <TileCaption position='left below'>
+                    left below
+                  </TileCaption>
                   <Placeholder />
                 </Tile>
               </div>
             </div>
           </PropExample>
-        </DocSection>
-
-        <DocSection title='Example'>
-          <div className='row'>
-            <div className='col-sm-4'>
-              <HoverHandler>
-                {({ hovering }) =>
-                  <AnimationHandler type='zoom' animating={hovering}>
-                    <Tile>
-                      <TileCaption
-                        title='Shonda Rhimes'
-                        subtitle='Teaches Writing'
-                        position={hovering ? 'left below' : 'left bottom'}
-                      />
-                      <Placeholder />
-                    </Tile>
-                  </AnimationHandler>
-                }
-              </HoverHandler>
-            </div>
-          </div>
         </DocSection>
       </div>
     </div>

--- a/src/components/TileCheck/index.stories.js
+++ b/src/components/TileCheck/index.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { withProps } from '../../utils/addon-props'
 
 import DocSection from '../../utils/DocSection'
 import PropExample from '../../utils/PropExample'
@@ -10,7 +11,7 @@ import TileCheck from '../TileCheck'
 
 
 storiesOf('components|Tiles/TileCheck', module)
-  .add('TileCheck', () => (
+  .add('TileCheck', withProps(TileCheck)(() => (
     <div className='container'>
       <div className='container'>
         <h2 className='mc-text-h2'>TileCheck</h2>
@@ -49,4 +50,4 @@ storiesOf('components|Tiles/TileCheck', module)
         </DocSection>
       </div>
     </div>
-  ))
+  )))

--- a/src/components/TileImage/index.js
+++ b/src/components/TileImage/index.js
@@ -1,11 +1,14 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
+import Background from '../Background'
+
 export default class TileImage extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
-    imageUrl: PropTypes.string.isRequired,
+    image: PropTypes.node,
+    imageUrl: PropTypes.string,
   }
 
   static defaultProps = {
@@ -16,6 +19,7 @@ export default class TileImage extends PureComponent {
     const {
       className,
       children,
+      image,
       imageUrl,
     } = this.props
 
@@ -27,15 +31,18 @@ export default class TileImage extends PureComponent {
 
     return (
       <div className={classes}>
-        <div
-          className='mc-tile-image__image background'
-          style={{ backgroundImage: `url('${imageUrl}')` }}
-        />
-        {children &&
-          <div className='mc-tile__content content'>
-            {children}
-          </div>
-        }
+        <Background
+          className='mc-tile-image__image'
+          element={image || <img src={imageUrl} />}
+          fit='container'
+          size='cover'
+        >
+          {children &&
+            <div className='mc-tile-image__content'>
+              {children}
+            </div>
+          }
+        </Background>
       </div>
     )
   }

--- a/src/components/TileImage/index.stories.js
+++ b/src/components/TileImage/index.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { withProps } from '../../utils/addon-props'
 
 import DocSection from '../../utils/DocSection'
 import PropExample from '../../utils/PropExample'
@@ -11,20 +12,20 @@ import shondaRhimesThumbnail from '../../utils/shonda-rhimes.png'
 
 
 storiesOf('components|Tiles/TileImage', module)
-  .add('TileImage', () => (
+  .add('TileImage', withProps(TileImage)(() => (
     <div className='container'>
       <div className='container'>
         <h2 className='mc-text-h2'>TileImage</h2>
 
         <DocSection title='Props'>
           <PropExample
-            name='imageUrl'
+            name='image'
             type='String'
           >
             <div className='row'>
               <div className='col-sm-6'>
                 <Tile>
-                  <TileImage imageUrl={shondaRhimesThumbnail} />
+                  <TileImage image={<img src={shondaRhimesThumbnail} />} />
                 </Tile>
               </div>
             </div>
@@ -32,4 +33,4 @@ storiesOf('components|Tiles/TileImage', module)
         </DocSection>
       </div>
     </div>
-  ))
+  )))

--- a/src/components/TileOverlay/index.stories.js
+++ b/src/components/TileOverlay/index.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { withProps } from '../../utils/addon-props'
 
 import DocSection from '../../utils/DocSection'
 import PropExample from '../../utils/PropExample'
@@ -12,7 +13,7 @@ import shondaRhimesThumbnail from '../../utils/shonda-rhimes.png'
 
 
 storiesOf('components|Tiles/TileOverlay', module)
-  .add('TileOverlay', () => (
+  .add('TileOverlay', withProps(TileOverlay)(() => (
     <div className='container'>
       <div className='container'>
         <h2 className='mc-text-h2'>TileOverlay</h2>
@@ -34,4 +35,4 @@ storiesOf('components|Tiles/TileOverlay', module)
         </DocSection>
       </div>
     </div>
-  ))
+  )))

--- a/src/styles/components/_background.scss
+++ b/src/styles/components/_background.scss
@@ -77,6 +77,15 @@
     }
   }
 
+  &--fit-container {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  &--fit-container,
   &--fit-content {
     .mc-background__background-container {
       position: absolute;
@@ -85,6 +94,7 @@
     }
   }
 
+  &--fit-container,
   &--fit-background {
     .mc-background__content-container {
       position: absolute;

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -36,7 +36,6 @@
     width: 100%;
     height: 100%;
     border-radius: 2px;
-    box-shadow: inset 0 0 0 1px rgba($mc-light, 0.1);
     z-index: 2;
   }
 
@@ -183,7 +182,7 @@
 .mc-tile-caption {
   z-index: 2;
 
-  &__titles {
+  &__content {
     position: absolute;
     padding: 16px;
     width: 100%;
@@ -194,7 +193,7 @@
 
   // Modifiers
   &--bottom {
-    .mc-tile-caption__titles {
+    .mc-tile-caption__content {
       left: 0;
       top: 100%;
       transform: translateY(-100%);
@@ -202,7 +201,7 @@
   }
 
   &--below {
-    .mc-tile-caption__titles {
+    .mc-tile-caption__content {
       left: 0;
       top: 100%;
       transform: translateY(0);
@@ -212,7 +211,7 @@
   }
 
   &--center {
-    .mc-tile-caption__titles {
+    .mc-tile-caption__content {
       text-align: center;
     }
   }

--- a/src/styles/typography/modifiers.scss
+++ b/src/styles/typography/modifiers.scss
@@ -7,7 +7,8 @@
 
   // Weight / opacity
   &--bold { font-weight: 600 !important; }
-  &--normal { font-weight: 400 !important; }
+  &--normal { font-weight: 500 !important; }
+  &--light { font-weight: 400 !important; }
   &--muted { opacity: 0.5 !important; }
 
   // Treatments


### PR DESCRIPTION
## Overview
A handful of improvements to Tile components:

- TileImage implements Background, which allows MC to pass it a Cloudinary image without "clouding" up the component library
- TileCaption removed `title` and `subtitle` so that users can pass their own typographic needs as `children`
- Removed inset border of Tile

## Risks
None - while they introduce breaking changes, they are not currently used in MC

## Changes
-

## Issue
#195 #198

