### PR TITLE
Updating variables in storybook to reflect current breakpoint variables

### DIFF
--- a/src/foundation/variables/index.stories.js
+++ b/src/foundation/variables/index.stories.js
@@ -200,7 +200,7 @@ storiesOf('foundation|Variables', module)
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$mc-bp-lg:</span>
-                <span className='mc-text--bold'>992px</span>
+                <span className='mc-text--bold'>960px</span>
               </p>
             </li>
             <li className='mc-example-breakpoint'>


### PR DESCRIPTION
The variables "story" wasn't updated when the grid variable was updated. This brings them in sync.