### PR TITLE
Updating breakpoints

### DIFF
--- a/.storybook/_upside-down.scss
+++ b/.storybook/_upside-down.scss
@@ -204,6 +204,41 @@ a {
   }
 }
 
+// Inline variables magically, thanks @jones for
+// the idea. You're so smart.
+ .mc-gutter-value {
+  &:before {
+    content: "#{$grid-gutter-width}";
+  }
+
+  &--xl:before {
+    content: "#{$grid-gutter-width-xl}";
+  }
+ }
+
+.mc-bp-value {
+  &--xs:before {
+    content: "#{$mc-bp-xs}";
+  }
+
+  &--sm:before {
+    content: "#{$mc-bp-sm}";
+  }
+
+  &--md:before {
+    content: "#{$mc-bp-md}";
+  }
+
+  &--lg:before {
+    content: "#{$mc-bp-lg}";
+  }
+
+  &--xl:before {
+    content: "#{$mc-bp-xl}";
+  }
+}
+
+
 .d-inline-block {
   display: inline-block;
 }

--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -20,158 +20,156 @@ import shondaRhimesThumbnail from '../../utils/shonda-rhimes.png'
 storiesOf('components|Tiles', module)
   .add('Summary', () => (
     <div className='container'>
-      <div className='container'>
-        <h2 className='mc-text-h2'>Tile</h2>
+      <h2 className='mc-text-h2'>Tile</h2>
 
-        <div className='row'>
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='Tile'>
-              <Tile>
-                <Placeholder>
-                  (empty)
-                </Placeholder>
-              </Tile>
-            </DocSection>
-          </div>
-
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='TileOverlay'>
-              <Tile>
-                <TileOverlay type='gradient-bottom' />
-                <Placeholder />
-              </Tile>
-            </DocSection>
-          </div>
-
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='TileCaption'>
-              <Tile>
-                <TileCaption>
-                  <h3 className='mc-text-h4 mc-text--uppercase'>
-                    Shonda Rhimes
-                  </h3>
-                  <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
-                    Teaches Writing
-                  </h4>
-                </TileCaption>
-                <Placeholder />
-              </Tile>
-            </DocSection>
-          </div>
-
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='TileCheck'>
-              <Tile>
-                <TileCheck checked />
-                <Placeholder />
-              </Tile>
-            </DocSection>
-          </div>
-
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='TileImage'>
-              <Tile>
-                <TileImage imageUrl={shondaRhimesThumbnail} />
-              </Tile>
-            </DocSection>
-          </div>
-
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='TileVideo'>
-              <Tile>
-                <TileVideo videoId='5450137526001' autoPlay loop muted />
-              </Tile>
-            </DocSection>
-          </div>
+      <div className='row'>
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='Tile'>
+            <Tile>
+              <Placeholder>
+                (empty)
+              </Placeholder>
+            </Tile>
+          </DocSection>
         </div>
 
-        <hr />
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='TileOverlay'>
+            <Tile>
+              <TileOverlay type='gradient-bottom' />
+              <Placeholder />
+            </Tile>
+          </DocSection>
+        </div>
 
-        <div className='row'>
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='Animations'>
-              <HoverHandler>
-                {({ hovering }) =>
-                  <Tile>
-                    <TileCheck>
-                      {() =>
-                        <Fragment>
-                          <AnimationHandler
-                            type='ken-burns'
-                            animating={hovering}
-                          >
-                            <TileImage imageUrl={shondaRhimesThumbnail} />
-                          </AnimationHandler>
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='TileCaption'>
+            <Tile>
+              <TileCaption>
+                <h3 className='mc-text-h4 mc-text--uppercase'>
+                  Shonda Rhimes
+                </h3>
+                <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                  Teaches Writing
+                </h4>
+              </TileCaption>
+              <Placeholder />
+            </Tile>
+          </DocSection>
+        </div>
 
-                          <TileOverlay type='gradient-bottom' />
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='TileCheck'>
+            <Tile>
+              <TileCheck checked />
+              <Placeholder />
+            </Tile>
+          </DocSection>
+        </div>
 
-                          <AnimationHandler
-                            type='lift'
-                            animating={hovering}
-                          >
-                            <TileCaption>
-                              <h3 className='mc-text-h4 mc-text--uppercase'>
-                                Shonda Rhimes
-                              </h3>
-                              <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
-                                Teaches Writing
-                              </h4>
-                            </TileCaption>
-                          </AnimationHandler>
-                        </Fragment>
-                      }
-                    </TileCheck>
-                  </Tile>
-                }
-              </HoverHandler>
-            </DocSection>
-          </div>
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='TileImage'>
+            <Tile>
+              <TileImage imageUrl={shondaRhimesThumbnail} />
+            </Tile>
+          </DocSection>
+        </div>
 
-          <div className='col-lg-4 col-md-6'>
-            <DocSection title='Swap'>
-              <HoverHandler>
-                {({ hovering }) =>
-                  <AnimationHandler
-                    type='zoom'
-                    animating={hovering}
-                  >
-                    <Tile>
-                      {!hovering &&
-                        <Fragment>
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='TileVideo'>
+            <Tile>
+              <TileVideo videoId='5450137526001' autoPlay loop muted />
+            </Tile>
+          </DocSection>
+        </div>
+      </div>
+
+      <hr />
+
+      <div className='row'>
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='Animations'>
+            <HoverHandler>
+              {({ hovering }) =>
+                <Tile>
+                  <TileCheck>
+                    {() =>
+                      <Fragment>
+                        <AnimationHandler
+                          type='ken-burns'
+                          animating={hovering}
+                        >
                           <TileImage imageUrl={shondaRhimesThumbnail} />
-                          <TileOverlay type='gradient-bottom' />
-                        </Fragment>
-                      }
-                      {hovering &&
-                        <Fragment>
-                          <TileVideo
-                            videoId='5450137526001'
-                            autoPlay
-                            loop
-                            muted
-                          />
-                        </Fragment>
-                      }
+                        </AnimationHandler>
 
-                      <TileCaption
-                        position={hovering
-                          ? 'left below'
-                          : 'left bottom'
-                        }
-                      >
-                        <h3 className='mc-text-h4 mc-text--uppercase'>
-                          Shonda Rhimes
-                        </h3>
-                        <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
-                          Teaches Writing
-                        </h4>
-                      </TileCaption>
-                    </Tile>
-                  </AnimationHandler>
-                }
-              </HoverHandler>
-            </DocSection>
-          </div>
+                        <TileOverlay type='gradient-bottom' />
+
+                        <AnimationHandler
+                          type='lift'
+                          animating={hovering}
+                        >
+                          <TileCaption>
+                            <h3 className='mc-text-h4 mc-text--uppercase'>
+                              Shonda Rhimes
+                            </h3>
+                            <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                              Teaches Writing
+                            </h4>
+                          </TileCaption>
+                        </AnimationHandler>
+                      </Fragment>
+                    }
+                  </TileCheck>
+                </Tile>
+              }
+            </HoverHandler>
+          </DocSection>
+        </div>
+
+        <div className='col-lg-4 col-md-6'>
+          <DocSection title='Swap'>
+            <HoverHandler>
+              {({ hovering }) =>
+                <AnimationHandler
+                  type='zoom'
+                  animating={hovering}
+                >
+                  <Tile>
+                    {!hovering &&
+                      <Fragment>
+                        <TileImage imageUrl={shondaRhimesThumbnail} />
+                        <TileOverlay type='gradient-bottom' />
+                      </Fragment>
+                    }
+                    {hovering &&
+                      <Fragment>
+                        <TileVideo
+                          videoId='5450137526001'
+                          autoPlay
+                          loop
+                          muted
+                        />
+                      </Fragment>
+                    }
+
+                    <TileCaption
+                      position={hovering
+                        ? 'left below'
+                        : 'left bottom'
+                      }
+                    >
+                      <h3 className='mc-text-h4 mc-text--uppercase'>
+                        Shonda Rhimes
+                      </h3>
+                      <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                        Teaches Writing
+                      </h4>
+                    </TileCaption>
+                  </Tile>
+                </AnimationHandler>
+              }
+            </HoverHandler>
+          </DocSection>
         </div>
       </div>
     </div>
@@ -181,70 +179,68 @@ storiesOf('components|Tiles', module)
 storiesOf('components|Tiles/Tile', module)
   .add('Tile', () => (
     <div className='container'>
-      <div className='container'>
-        <h2 className='mc-text-h2'>Tile</h2>
+      <h2 className='mc-text-h2'>Tile</h2>
 
-        <DocSection title='Variations'>
-          <PropExample
-            name='aspectRatio'
-            type='String'
-          >
-            <div className='row'>
-              <div className='col-sm-4'>
-                <Tile aspectRatio='16x9'>
-                  <Placeholder>16x9</Placeholder>
-                </Tile>
-              </div>
-              <div className='col-sm-4'>
-                <Tile aspectRatio='16x9'>
-                  <Placeholder>16x9</Placeholder>
-                </Tile>
-              </div>
-              <div className='col-sm-4'>
-                <Tile aspectRatio='16x9'>
-                  <Placeholder>16x9</Placeholder>
-                </Tile>
-              </div>
-
-              <div className='col-sm-12'>
-                <Tile aspectRatio='519x187'>
-                  <Placeholder>519x187</Placeholder>
-                </Tile>
-              </div>
-
-              <div className='col-sm-2'>
-                <Tile aspectRatio='4x3'>
-                  <Placeholder>4x3</Placeholder>
-                </Tile>
-              </div>
-              <div className='col-sm-2'>
-                <Tile aspectRatio='4x3'>
-                  <Placeholder>4x3</Placeholder>
-                </Tile>
-              </div>
-              <div className='col-sm-2'>
-                <Tile aspectRatio='4x3'>
-                  <Placeholder>4x3</Placeholder>
-                </Tile>
-              </div>
-              <div className='col-sm-2'>
-                <Tile aspectRatio='4x3'>
-                  <Placeholder>4x3</Placeholder>
-                </Tile>
-              </div>
-              <div className='col-sm-2'>
-                <Tile aspectRatio='4x3'>
-                  <Placeholder>4x3</Placeholder>
-                </Tile>
-              </div>
-              <div className='col-sm-2'>
-                <Tile aspectRatio='4x3'>
-                  <Placeholder>4x3</Placeholder>
-                </Tile>
-              </div>
+      <DocSection title='Variations'>
+        <PropExample
+          name='aspectRatio'
+          type='String'
+        >
+          <div className='row'>
+            <div className='col-sm-4'>
+              <Tile aspectRatio='16x9'>
+                <Placeholder>16x9</Placeholder>
+              </Tile>
             </div>
-          </PropExample>
-        </DocSection>
-      </div>
+            <div className='col-sm-4'>
+              <Tile aspectRatio='16x9'>
+                <Placeholder>16x9</Placeholder>
+              </Tile>
+            </div>
+            <div className='col-sm-4'>
+              <Tile aspectRatio='16x9'>
+                <Placeholder>16x9</Placeholder>
+              </Tile>
+            </div>
+
+            <div className='col-sm-12'>
+              <Tile aspectRatio='519x187'>
+                <Placeholder>519x187</Placeholder>
+              </Tile>
+            </div>
+
+            <div className='col-sm-2'>
+              <Tile aspectRatio='4x3'>
+                <Placeholder>4x3</Placeholder>
+              </Tile>
+            </div>
+            <div className='col-sm-2'>
+              <Tile aspectRatio='4x3'>
+                <Placeholder>4x3</Placeholder>
+              </Tile>
+            </div>
+            <div className='col-sm-2'>
+              <Tile aspectRatio='4x3'>
+                <Placeholder>4x3</Placeholder>
+              </Tile>
+            </div>
+            <div className='col-sm-2'>
+              <Tile aspectRatio='4x3'>
+                <Placeholder>4x3</Placeholder>
+              </Tile>
+            </div>
+            <div className='col-sm-2'>
+              <Tile aspectRatio='4x3'>
+                <Placeholder>4x3</Placeholder>
+              </Tile>
+            </div>
+            <div className='col-sm-2'>
+              <Tile aspectRatio='4x3'>
+                <Placeholder>4x3</Placeholder>
+              </Tile>
+            </div>
+          </div>
+        </PropExample>
+      </DocSection>
     </div>
   ))

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -13,44 +13,42 @@ import TileCaption from '../TileCaption'
 storiesOf('components|Tiles/TileCaption', module)
   .add('TileCaption', withProps(TileCaption)(() => (
     <div className='container'>
-      <div className='container'>
-        <h2 className='mc-text-h2'>TileCaption</h2>
+      <h2 className='mc-text-h2'>TileCaption</h2>
 
-        <DocSection title='Variants'>
-          <PropExample
-            name='position'
-            type='String'
-          >
-            <div className='row'>
-              <div className='col-sm-4'>
-                <Tile>
-                  <TileCaption position='left bottom'>
-                    left bottom
-                  </TileCaption>
-                  <Placeholder />
-                </Tile>
-              </div>
-
-              <div className='col-sm-4'>
-                <Tile>
-                  <TileCaption position='center bottom'>
-                    center bottom
-                  </TileCaption>
-                  <Placeholder />
-                </Tile>
-              </div>
-
-              <div className='col-sm-4'>
-                <Tile>
-                  <TileCaption position='left below'>
-                    left below
-                  </TileCaption>
-                  <Placeholder />
-                </Tile>
-              </div>
+      <DocSection title='Variants'>
+        <PropExample
+          name='position'
+          type='String'
+        >
+          <div className='row'>
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='left bottom'>
+                  left bottom
+                </TileCaption>
+                <Placeholder />
+              </Tile>
             </div>
-          </PropExample>
-        </DocSection>
-      </div>
+
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='center bottom'>
+                  center bottom
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='left below'>
+                  left below
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+          </div>
+        </PropExample>
+      </DocSection>
     </div>
   )))

--- a/src/components/TileCheck/index.stories.js
+++ b/src/components/TileCheck/index.stories.js
@@ -13,41 +13,39 @@ import TileCheck from '../TileCheck'
 storiesOf('components|Tiles/TileCheck', module)
   .add('TileCheck', withProps(TileCheck)(() => (
     <div className='container'>
-      <div className='container'>
-        <h2 className='mc-text-h2'>TileCheck</h2>
+      <h2 className='mc-text-h2'>TileCheck</h2>
 
-        <DocSection title='Props'>
-          <PropExample
-            name='checked'
-            type='Boolean'
-          >
-            <div className='row'>
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileCheck checked>
-                    {({ checked }) =>
-                      <Placeholder>
-                        {checked ? 'true' : 'false'}
-                      </Placeholder>
-                    }
-                  </TileCheck>
-                </Tile>
-              </div>
-
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileCheck>
-                    {({ checked }) =>
-                      <Placeholder>
-                        {checked ? 'true' : 'false'}
-                      </Placeholder>
-                    }
-                  </TileCheck>
-                </Tile>
-              </div>
+      <DocSection title='Props'>
+        <PropExample
+          name='checked'
+          type='Boolean'
+        >
+          <div className='row'>
+            <div className='col-sm-6'>
+              <Tile>
+                <TileCheck checked>
+                  {({ checked }) =>
+                    <Placeholder>
+                      {checked ? 'true' : 'false'}
+                    </Placeholder>
+                  }
+                </TileCheck>
+              </Tile>
             </div>
-          </PropExample>
-        </DocSection>
-      </div>
+
+            <div className='col-sm-6'>
+              <Tile>
+                <TileCheck>
+                  {({ checked }) =>
+                    <Placeholder>
+                      {checked ? 'true' : 'false'}
+                    </Placeholder>
+                  }
+                </TileCheck>
+              </Tile>
+            </div>
+          </div>
+        </PropExample>
+      </DocSection>
     </div>
   )))

--- a/src/components/TileImage/index.stories.js
+++ b/src/components/TileImage/index.stories.js
@@ -14,23 +14,21 @@ import shondaRhimesThumbnail from '../../utils/shonda-rhimes.png'
 storiesOf('components|Tiles/TileImage', module)
   .add('TileImage', withProps(TileImage)(() => (
     <div className='container'>
-      <div className='container'>
-        <h2 className='mc-text-h2'>TileImage</h2>
+      <h2 className='mc-text-h2'>TileImage</h2>
 
-        <DocSection title='Props'>
-          <PropExample
-            name='image'
-            type='String'
-          >
-            <div className='row'>
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileImage image={<img src={shondaRhimesThumbnail} />} />
-                </Tile>
-              </div>
+      <DocSection title='Props'>
+        <PropExample
+          name='image'
+          type='String'
+        >
+          <div className='row'>
+            <div className='col-sm-6'>
+              <Tile>
+                <TileImage image={<img src={shondaRhimesThumbnail} />} />
+              </Tile>
             </div>
-          </PropExample>
-        </DocSection>
-      </div>
+          </div>
+        </PropExample>
+      </DocSection>
     </div>
   )))

--- a/src/components/TileOverlay/index.stories.js
+++ b/src/components/TileOverlay/index.stories.js
@@ -15,24 +15,22 @@ import shondaRhimesThumbnail from '../../utils/shonda-rhimes.png'
 storiesOf('components|Tiles/TileOverlay', module)
   .add('TileOverlay', withProps(TileOverlay)(() => (
     <div className='container'>
-      <div className='container'>
-        <h2 className='mc-text-h2'>TileOverlay</h2>
+      <h2 className='mc-text-h2'>TileOverlay</h2>
 
-        <DocSection title='Props'>
-          <PropExample
-            name='type'
-            type='String["gradient-bottom"]'
-          >
-            <div className='row'>
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileImage imageUrl={shondaRhimesThumbnail} />
-                  <TileOverlay type='gradient-bottom' />
-                </Tile>
-              </div>
+      <DocSection title='Props'>
+        <PropExample
+          name='type'
+          type='String["gradient-bottom"]'
+        >
+          <div className='row'>
+            <div className='col-sm-6'>
+              <Tile>
+                <TileImage imageUrl={shondaRhimesThumbnail} />
+                <TileOverlay type='gradient-bottom' />
+              </Tile>
             </div>
-          </PropExample>
-        </DocSection>
-      </div>
+          </div>
+        </PropExample>
+      </DocSection>
     </div>
   )))

--- a/src/components/TileVideo/index.stories.js
+++ b/src/components/TileVideo/index.stories.js
@@ -12,62 +12,60 @@ import TileVideo from '../TileVideo'
 storiesOf('components|Tiles/TileVideo', module)
   .add('TileVideo', withProps(TileVideo)(() => (
     <div className='container'>
-      <div className='container'>
-        <h2 className='mc-text-h2'>TileVideo</h2>
+      <h2 className='mc-text-h2'>TileVideo</h2>
 
-        <DocSection title='Props'>
-          <PropExample
-            name='autoPlay'
-            type='Boolean'
-          >
-            <div className='row'>
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileVideo videoId='5450137526001' autoPlay />
-                </Tile>
-              </div>
+      <DocSection title='Props'>
+        <PropExample
+          name='autoPlay'
+          type='Boolean'
+        >
+          <div className='row'>
+            <div className='col-sm-6'>
+              <Tile>
+                <TileVideo videoId='5450137526001' autoPlay />
+              </Tile>
             </div>
-          </PropExample>
+          </div>
+        </PropExample>
 
-          <PropExample
-            name='controls'
-            type='Boolean'
-          >
-            <div className='row'>
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileVideo videoId='5450137526001' controls />
-                </Tile>
-              </div>
+        <PropExample
+          name='controls'
+          type='Boolean'
+        >
+          <div className='row'>
+            <div className='col-sm-6'>
+              <Tile>
+                <TileVideo videoId='5450137526001' controls />
+              </Tile>
             </div>
-          </PropExample>
+          </div>
+        </PropExample>
 
-          <PropExample
-            name='loop'
-            type='Boolean'
-          >
-            <div className='row'>
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileVideo videoId='5450137526001' controls loop />
-                </Tile>
-              </div>
+        <PropExample
+          name='loop'
+          type='Boolean'
+        >
+          <div className='row'>
+            <div className='col-sm-6'>
+              <Tile>
+                <TileVideo videoId='5450137526001' controls loop />
+              </Tile>
             </div>
-          </PropExample>
+          </div>
+        </PropExample>
 
-          <PropExample
-            name='muted'
-            type='Boolean'
-          >
-            <div className='row'>
-              <div className='col-sm-6'>
-                <Tile>
-                  <TileVideo videoId='5450137526001' controls muted />
-                </Tile>
-              </div>
+        <PropExample
+          name='muted'
+          type='Boolean'
+        >
+          <div className='row'>
+            <div className='col-sm-6'>
+              <Tile>
+                <TileVideo videoId='5450137526001' controls muted />
+              </Tile>
             </div>
-          </PropExample>
-        </DocSection>
-      </div>
+          </div>
+        </PropExample>
+      </DocSection>
     </div>
   )))

--- a/src/foundation/variables/index.stories.js
+++ b/src/foundation/variables/index.stories.js
@@ -170,43 +170,43 @@ storiesOf('foundation|Variables', module)
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$grid-gutter-width:</span>
-                <span className='mc-text--bold'>16px</span>
+                <span className='mc-text--bold mc-gutter-value'></span>
               </p>
             </li>
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$grid-gutter-width-xl:</span>
-                <span className='mc-text--bold'>32px</span>
+                <span className='mc-text--bold mc-gutter-value--xl'></span>
               </p>
             </li>
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$mc-bp-xs:</span>
-                <span className='mc-text--bold'>0</span>
+                <span className='mc-text--bold mc-bp-value--xs'></span>
               </p>
             </li>
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$mc-bp-sm:</span>
-                <span className='mc-text--bold'>576px</span>
+                <span className='mc-text--bold mc-bp-value--sm'></span>
               </p>
             </li>
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$mc-bp-md:</span>
-                <span className='mc-text--bold'>768px</span>
+                <span className='mc-text--bold mc-bp-value--md'></span>
               </p>
             </li>
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$mc-bp-lg:</span>
-                <span className='mc-text--bold'>960px</span>
+                <span className='mc-text--bold mc-bp-value--lg'></span>
               </p>
             </li>
             <li className='mc-example-breakpoint'>
               <p className='mc-text--monospace'>
                 <span className='mc-text--muted'>$mc-bp-xl:</span>
-                <span className='mc-text--bold'>1200px</span>
+                <span className='mc-text--bold mc-bp-value--xl'></span>
               </p>
             </li>
           </ul>

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -133,9 +133,9 @@ $grid-breakpoints: (
 ) !default;
 
 $container-max-widths: (
-  sm: $mc-bp-sm + (2 * $container-margin-sm),
-  md: $mc-bp-md + (2 * $container-margin-md),
-  lg: $mc-bp-lg + (2 * $container-margin-lg),
+  sm: 100%,
+  md: 100%,
+  lg: 100%,
   xl: $mc-bp-xl + (2 * $container-margin-xl)
 ) !default;
 

--- a/src/styles/libraries/bootstrap-overrides/_grid.scss
+++ b/src/styles/libraries/bootstrap-overrides/_grid.scss
@@ -21,6 +21,10 @@
 }
 
 // Responsive
+@media only screen and (min-width: $mc-bp-sm) {
+  .container { padding: 0 ($grid-gutter-width-sm * 2); }
+}
+
 @media only screen and (min-width: $mc-bp-md) {
   .container { padding: 0 ($grid-gutter-width-md * 2); }
 }


### PR DESCRIPTION
## Overview
There was a misalignment of expectations between design and development on how the grid works.  We spoke with Sean and got clarification on how design would like to have the grid implemented and these code changes reflect those discussions.

## THIS IS A POTENTIALLY BREAKING CHANGE
Any components using the existing grid might have edge cases while hitting breakpoints that could visually break them.  @jstnjns and I will be going through existing components to verify there are no breaking changes as well as the masterclass repo before versioning mc-components.  We would like to get this change in ASAP so any developers building new components will be using the grid now vs later.  There should be a separate PR in the next few days to adjust any existing components to work with the new grid.

## Things to check
Per Jesse, these items in the main masterclass repo may be affected by this change:
- Playlists and LIHP 
- 7 day lesson plan
- onboarding (red carpet)

## Risks
Medium - High, lots of potential issues with resizing components with the new grid.  The max widths and breakpoints that we were using before don't necessarily apply.

## Changes
Changes can be viewed on the grid storybook example.

When merged into masterclass, we should reference [[WI-21]](https://masterclass-dev.atlassian.net/browse/WI-21)
## Issue
N/A
