### PR TITLE
Updating color variables

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -12,29 +12,28 @@ $mc-color-light:             #fff !default;
 $mc-color-dark:              #000 !default;
 
 // Colors
+$mc-color-gray-100:           #191c21 !default;
+$mc-color-gray-200:           #272c33 !default;
+$mc-color-gray-300:           #31333b !default;
+$mc-color-gray-400:           #596170 !default;
+$mc-color-gray-500:           #949aa4 !default;
+$mc-color-gray-600:           #dbdde1 !default;
+
 $mc-color-primary:           #c83232 !default;
 $mc-color-primary-hover:     #d63636 !default;
 $mc-color-primary-active:    #b22b2b !default;
 
-$mc-color-secondary:         #232325 !default;
-$mc-color-secondary-hover:   #2c2c2e !default;
-$mc-color-secondary-active:  #1f1f21 !default;
+$mc-color-secondary:         $mc-color-gray-200 !default;
+$mc-color-secondary-hover:   $mc-color-gray-300 !default;
+$mc-color-secondary-active:  $mc-color-gray-100 !default;
 
-$mc-color-tertiary:          #75787f !default;
-$mc-color-tertiary-hover:    #90949d !default;
+$mc-color-tertiary:          $mc-color-gray-400 !default;
+$mc-color-tertiary-hover:    $mc-color-gray-500 !default;
 
 $mc-color-background:        #090909 !default;
 $mc-color-background-invert: #ebeeee !default;
 $mc-color-text:              $mc-color-light !default;
 $mc-color-text-invert:       #8ca1c1 !default;
-
-// Not quite 50 of them, but...
-$mc-color-gray-100:           #272c33 !default;
-$mc-color-gray-200:           #191c21 !default;
-$mc-color-gray-300:           #31333b !default;
-$mc-color-gray-400:           #596170 !default;
-$mc-color-gray-500:           #949aa4 !default;
-$mc-color-gray-600:           #dbdde1 !default;
 
 $mc-color-error:        rgba($mc-color-primary, 0.6) !default;
 $mc-color-warning:      rgba($mc-color-primary, 0.6) !default;

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -17,6 +17,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+::selection {
+  background: rgba($mc-color-gray-500, 0.3);
+}
+
+
 a { text-decoration: none; }
 
 // Big "display" text


### PR DESCRIPTION
## Overview
Grays were out of order and corrected in figma comp, so updating here as well.

## Risks
Low, but colors may change if they were using the variables (intentionally / acceptable though)

## Changes
Grays can now be used gray-100 (darkest) to gray-600 (lightest) as one would expect.  Also cleaned up "slightly different" grays used in edge cases to instead use the closest standard grays available (secondary / tertiary variables).

## Issue
https://github.com/yankaindustries/mc-components/issues/210