### PR TITLE
Legacy classnames

### DIFF
--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -8,7 +8,9 @@
     content: "";
   }
 
-  .mc-tile__content {
+  .mc-tile__content,
+  .background,
+  .content {
     position: absolute;
     left: 0;
     top: 0;

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -7,20 +7,9 @@
     padding-top: ($height / $width) * 100%;
     content: "";
   }
-
-  .mc-tile__content,
-  .background,
-  .content {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-  }
 }
 
-.mc-tile,
-.tile {
+.mc-tile {
   position: relative;
   backface-visibility: hidden;
   border-radius: 2px;
@@ -39,6 +28,14 @@
     height: 100%;
     border-radius: 2px;
     z-index: 2;
+  }
+
+  &__content {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
   }
 
   &--naked {


### PR DESCRIPTION
## Overview
We are removing a legacy tile classnames as they are just conflicting with what's on prod, and should be cleaned out anyway.

## Risks
Low - We checked tile implementations in `masterclass` to see if there were any conflicts with removing these classes, they are using the local implementation anyway so there appears to be no issue...so long as we didn't miss any.