### PR TITLE
Add dev mode for auto-recompiling on changes

### DIFF
--- a/.storybook/_upside-down.scss
+++ b/.storybook/_upside-down.scss
@@ -38,10 +38,6 @@
   }
 }
 
-body {
-  background: $mc-color-background;
-}
-
 pre {
   font-family: monospace;
 }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ const Container = () =>
 
 All changes are hot-reloaded and you'll be able to see components being modified live as you work.
 
+If you want to develop in `mc-components` and see your work compiled live in your own project (like the masterclass repo), then you can use the following command to hot-reload changes to styles and components:
+
+```
+yarn dev
+```
+
 ## Submit your code
   - Create a PR with your changes
   - Once approved, it will be merged into develop and released with the next version bump.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "rimraf ./dist",
+    "dev": "yarn dev:js && yarn dev:scss && yarn dev:css",
+    "dev:js": "babel ./src/components --watch --out-dir ./dist/components --ignore '**/*.stories.js,**/*.test.js'",
+    "dev:scss": "NODE_ENV=development mkdir -p ./dist/styles/scss && postcss ./src/styles --base ./src/styles --dir ./dist/styles/scss --watch",
+    "dev:css": "NODE_ENV=production mkdir -p ./dist/styles/css && node-sass ./src/styles/index.scss | postcss > ./dist/styles/css/index.css --watch",
     "build": "yarn build:assets && yarn build:js && yarn build:styles",
     "build:assets": "svgr ./src/assets/icons --out-dir ./src/components/Icons",
     "build:js": "babel ./src/components --out-dir ./dist/components --ignore '**/*.stories.js,**/*.test.js'",


### PR DESCRIPTION
## Overview
Adds build process to mc-components for hot reloading and recompiling for easier development and testing in other projects.

We had a "dev mode" before, but all changes needed to be checked in storybook. This PR adds:

```yarn dev```

Which recompiled all js and style assets so if you have `mc-components` linked locally, you'll be able to see your changes live in your project!

## Risks
Low