### PR TITLE
Adding `intent` value to HoverHandler

### DIFF
--- a/src/components/HoverHandler/index.js
+++ b/src/components/HoverHandler/index.js
@@ -15,6 +15,10 @@ export default class HoverHandler extends PureComponent {
     intent: false,
   }
 
+  componentWillUnmount () {
+    if (this.timer) this.timer = clearTimeout(this.timer)
+  }
+
   onEnter = () => {
     if (this.timer) this.timer = clearTimeout(this.timer)
 
@@ -32,7 +36,7 @@ export default class HoverHandler extends PureComponent {
     )
   }
 
-  onOut = () => {
+  onLeave = () => {
     if (this.timer) this.timer = clearTimeout(this.timer)
 
     this.setState({
@@ -53,7 +57,7 @@ export default class HoverHandler extends PureComponent {
     return (
       <span
         onMouseEnter={this.onEnter}
-        onMouseLeave={this.onOut}
+        onMouseLeave={this.onLeave}
       >
         {children({ hovering, intent })}
       </span>

--- a/src/components/HoverHandler/index.js
+++ b/src/components/HoverHandler/index.js
@@ -2,6 +2,9 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 
 
+const DELAY = 300
+
+
 export default class HoverHandler extends PureComponent {
   static propTypes = {
     children: PropTypes.func.isRequired,
@@ -9,27 +12,51 @@ export default class HoverHandler extends PureComponent {
 
   state = {
     hovering: false,
+    intent: false,
   }
 
-  onEnter () {
-    this.setState({ hovering: true })
+  onEnter = () => {
+    if (this.timer) this.timer = clearTimeout(this.timer)
+
+    this.setState({
+      hovering: true,
+    })
+
+    this.timer = setTimeout(
+      () => {
+        this.setState({
+          intent: true,
+        })
+      },
+      DELAY,
+    )
   }
 
-  onLeave () {
-    this.setState({ hovering: false })
+  onOut = () => {
+    if (this.timer) this.timer = clearTimeout(this.timer)
+
+    this.setState({
+      hovering: false,
+      intent: false,
+    })
   }
 
   render () {
-    const { children } = this.props
-    const { hovering } = this.state
+    const {
+      children,
+    } = this.props
+    const {
+      hovering,
+      intent,
+    } = this.state
 
     return (
-      <div
-        onMouseEnter={this.onEnter.bind(this)}
-        onMouseLeave={this.onLeave.bind(this)}
+      <span
+        onMouseEnter={this.onEnter}
+        onMouseLeave={this.onOut}
       >
-        {children({ hovering })}
-      </div>
+        {children({ hovering, intent })}
+      </span>
     )
   }
 }

--- a/src/components/HoverHandler/index.stories.js
+++ b/src/components/HoverHandler/index.stories.js
@@ -14,15 +14,13 @@ storiesOf('utilities|HoverHandler', module)
     <div className='container'>
       <h2>HoverHandler</h2>
 
-      <DocSection title='Variations'>
-        <PropExample
-          name='children'
-          type='RenderProp'
-        >
+      <DocSection>
+        <PropExample>
           <HoverHandler>
-            {({ hovering }) =>
-              <Button primary>
+            {({ hovering, intent }) =>
+              <Button>
                 {hovering ? 'Hovering' : 'Normal'}
+                {intent ? ' w/ Intent' : ''}
               </Button>
             }
           </HoverHandler>

--- a/src/components/HoverHandler/index.stories.js
+++ b/src/components/HoverHandler/index.stories.js
@@ -12,7 +12,9 @@ import Button from '../Button'
 storiesOf('utilities|HoverHandler', module)
   .add('default', withProps(HoverHandler)(() => (
     <div className='container'>
-      <h2>HoverHandler</h2>
+      <h2 className='mc-text-h2'>
+        HoverHandler
+      </h2>
 
       <DocSection>
         <PropExample>


### PR DESCRIPTION
## Overview
To avoid wild actions when cursor moves across a grid where tiles are listing for hover, we've added `intent` so that you can listen to hover only when the user has stopped moving the mouse.

## Risks
None - This is adding functionality, not changing any.