### PR TITLE
Subheader style fixed

### DIFF
--- a/src/styles/components/modal/_modal-header.scss
+++ b/src/styles/components/modal/_modal-header.scss
@@ -8,7 +8,7 @@
   text-align: center;
 }
 
-.mc-components-modal-header__subheader {
+.modal-header__subheader {
   color: rgba(#4d5768, 0.3);
   font-weight: 700;
   line-height: 2rem;


### PR DESCRIPTION
## Overview
Subheader style was not taking into consideration due to a wrong className.

## Risks
Minor fix, no risks.

## Issue
Now the modal will use the defined subheader style. 
