### PR TITLE
Remove unused --light style and readd --x-light to documentation

### DIFF
--- a/src/components/AnimationHandler/index.stories.js
+++ b/src/components/AnimationHandler/index.stories.js
@@ -76,7 +76,7 @@ storiesOf('utilities|AnimationHandler', module)
                       <h2 className='mc-text-h2 mc-text--uppercase'>
                         Shonda Rhimes
                       </h2>
-                      <h4 className='mc-text-h4 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                      <h4 className='mc-text-h4 mc-text--uppercase mc-text--muted mc-text--normal mc-text--airy'>
                         Teaches Writing for Television
                       </h4>
                     </TileCaption>

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -88,7 +88,7 @@ storiesOf('components|Carousel', module)
                     <h3 className='mc-text-h4 mc-text--uppercase'>
                       {item.instructor}
                     </h3>
-                    <h5 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                    <h5 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--normal mc-text--airy'>
                       {`Teaches ${item.teaches}`}
                     </h5>
                   </TileCaption>

--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -49,7 +49,7 @@ storiesOf('components|Tiles', module)
                 <h3 className='mc-text-h4 mc-text--uppercase'>
                   Shonda Rhimes
                 </h3>
-                <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--normal mc-text--airy'>
                   Teaches Writing
                 </h4>
               </TileCaption>
@@ -112,7 +112,7 @@ storiesOf('components|Tiles', module)
                             <h3 className='mc-text-h4 mc-text--uppercase'>
                               Shonda Rhimes
                             </h3>
-                            <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                            <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--normal mc-text--airy'>
                               Teaches Writing
                             </h4>
                           </TileCaption>
@@ -161,7 +161,7 @@ storiesOf('components|Tiles', module)
                       <h3 className='mc-text-h4 mc-text--uppercase'>
                         Shonda Rhimes
                       </h3>
-                      <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--light mc-text--airy'>
+                      <h4 className='mc-text-h5 mc-text--uppercase mc-text--muted mc-text--normal mc-text--airy'>
                         Teaches Writing
                       </h4>
                     </TileCaption>

--- a/src/foundation/type/index.stories.js
+++ b/src/foundation/type/index.stories.js
@@ -115,8 +115,14 @@ storiesOf('foundation|Type', module)
 
         <div className='align-items-center example--section'>
           <h5 className='mc-text-h5'>Font weight - Normal</h5>
-          <h1 className='mc-text-h1 mc-text--normal'>The quick brown fox jumped over the lazy dog.</h1>
-          <p className='mc-text--muted mc-text--monospace'>.mc-text--h1.mc-text--normal</p>
+          <h1 className='mc-text--normal'>The quick brown fox jumped over the lazy dog.</h1>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text--normal</p>
+        </div>
+
+        <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Font weight - Extra Light</h5>
+          <h1 className='mc-text--x-light'>The quick brown fox jumped over the lazy dog.</h1>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text--x-light</p>
         </div>
 
         <div className='align-items-center example--section'>

--- a/src/playground/home/index.stories.js
+++ b/src/playground/home/index.stories.js
@@ -109,7 +109,7 @@ storiesOf('playground|Pages', module)
                                   <h2 className='mc-text-d1 mc-text--uppercase mc-text--center mc-text-md--left'>
                                     {item.instructor}
                                   </h2>
-                                  <h2 className='mc-text-h2 mc-text--uppercase mc-text--muted mc-text--light mc-text--center mc-text-md--left mc-text--nowrap'>
+                                  <h2 className='mc-text-h2 mc-text--uppercase mc-text--muted mc-text--normal mc-text--center mc-text-md--left mc-text--nowrap'>
                                     Teaches {item.class}
                                   </h2>
                                   <br />
@@ -644,7 +644,7 @@ storiesOf('playground|Pages', module)
       <div className='container'>
         <div className='mc-section'>
           <div className='mc-section__header'>
-            <h4 className='mc-text-h4 mc-text--uppercase mc-text--muted mc-text--light mc-text--center'>
+            <h4 className='mc-text-h4 mc-text--uppercase mc-text--muted mc-text--normal mc-text--center'>
               Stay up to date with MasterClass
             </h4>
           </div>

--- a/src/styles/typography/modifiers.scss
+++ b/src/styles/typography/modifiers.scss
@@ -8,7 +8,6 @@
   // Weight / opacity
   &--bold { font-weight: 600 !important; }
   &--normal { font-weight: 500 !important; }
-  &--light { font-weight: 400 !important; }
   &--x-light { font-weight: 300 !important; }
   &--muted { opacity: 0.5 !important; }
 


### PR DESCRIPTION
## Overview
The current `--light` and `--normal` text modifier styles render the same since we only import a few font weights.  Update the storybook documentation to reflect this.

## Risks
None

## Issue
https://github.com/yankaindustries/mc-components/issues/234