### PR TITLE
Updating gutter widths after experimenting with real implementation

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -94,7 +94,7 @@ $transition-base:        all 0.2s ease-in-out !default;
 // Custom bootstrap grid overrides
 $grid-gutter-width:      16px !default;
 $grid-gutter-width-sm:   16px !default;
-$grid-gutter-width-md:   32px !default;
+$grid-gutter-width-md:   16px !default;
 $grid-gutter-width-lg:   32px !default;
 $grid-gutter-width-xl:   32px !default;
 
@@ -109,7 +109,7 @@ $grid-gutter-widths: (
 // container widths
 $container-margin: 16px !default;
 $container-margin-sm: 32px !default;
-$container-margin-md: 64px !default;
+$container-margin-md: 32px !default;
 $container-margin-lg: 64px !default;
 $container-margin-xl: 64px !default;
 

--- a/src/styles/libraries/bootstrap-overrides/_grid.scss
+++ b/src/styles/libraries/bootstrap-overrides/_grid.scss
@@ -30,6 +30,10 @@
   .container { padding: 0 ($grid-gutter-width-md * 2); }
 }
 
+@media only screen and (min-width: $mc-bp-lg) {
+  .container { padding: 0 ($grid-gutter-width-lg * 2); }
+}
+
 @media only screen and (min-width: $mc-bp-xl) {
   .container { padding: 0 ($grid-gutter-width-xl * 2); }
   .row { margin: $grid-gutter-width-xl / -2; }


### PR DESCRIPTION
## Overview
After building an example experiment, we realized the `64px` of padding on the container was excessive for tablets.

This PR updates the grid system to maintain the `32px` of left and right padding on the container until you hit the large breakpoint of `960px` before switching to the `64px` of padding.

## Risks
Low - all grids are being updated but this should give everything more breathing room.

## Changes
Old grid at `769px`:
![image](https://user-images.githubusercontent.com/505670/46701244-f001fc00-cbd3-11e8-8c0e-3a16491f13b5.png)

New grid at `769px`
![image](https://user-images.githubusercontent.com/505670/46701238-e7a9c100-cbd3-11e8-8caa-abbb2a4e3f57.png)


## Issue
https://github.com/yankaindustries/mc-components/issues/233