### PR TITLE
Add no-gutters-vertical class

### DIFF
--- a/src/foundation/grid/index.stories.js
+++ b/src/foundation/grid/index.stories.js
@@ -74,64 +74,132 @@ storiesOf('foundation|Grid', module)
         </CodeExample>
       </div>
 
-      <h2 className='mc-text-h2'>Grid (no-gutters)</h2>
-      <p className='mc-text--muted mc-text--monospace'>.row.no-gutters</p>
-      <CodeExample>
-        <div className='row no-gutters'>
-          <div className='col-6'>
-            <Placeholder className='example-grid-block'>.col-6</Placeholder>
+      <div className='example--section'>
+        <h2 className='mc-text-h2'>Grid (no-gutters)</h2>
+        <p className='mc-text--muted mc-text--monospace'>.row.no-gutters</p>
+        <CodeExample>
+          <div className='row no-gutters'>
+            <div className='col-6'>
+              <Placeholder className='example-grid-block'>.col-6</Placeholder>
+            </div>
+            <div className='col-6'>
+              <Placeholder className='example-grid-block'>.col-6</Placeholder>
+            </div>
+
+            <div className='col-sm-12 col-md-4'>
+              <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+            </div>
+            <div className='col-sm-12 col-md-4'>
+              <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+            </div>
+            <div className='col-sm-12 col-md-4'>
+              <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+            </div>
+
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
           </div>
-          <div className='col-6'>
-            <Placeholder className='example-grid-block'>.col-6</Placeholder>
+        </CodeExample>
+      </div>
+
+      <div className='example--section'>
+        <h2 className='mc-text-h2'>Grid (no-gutters-vertical)</h2>
+        <p className='mc-text--muted mc-text--monospace'>.row.no-gutters-vertical</p>
+        <CodeExample>
+          <div className='row no-gutters-vertical'>
+            <div className='col-6'>
+              <Placeholder className='example-grid-block'>.col-6</Placeholder>
+            </div>
+            <div className='col-6'>
+              <Placeholder className='example-grid-block'>.col-6</Placeholder>
+            </div>
           </div>
 
-          <div className='col-sm-12 col-md-4'>
-            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
-          </div>
-          <div className='col-sm-12 col-md-4'>
-            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
-          </div>
-          <div className='col-sm-12 col-md-4'>
-            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+          <div className='row no-gutters-vertical'>
+            <div className='col-sm-12 col-md-4'>
+              <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+            </div>
+            <div className='col-sm-12 col-md-4'>
+              <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+            </div>
+            <div className='col-sm-12 col-md-4'>
+              <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+            </div>
           </div>
 
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          <div className='row no-gutters-vertical'>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
+            <div className='col-md'>
+              <Placeholder className='example-grid-block'>.col-md</Placeholder>
+            </div>
           </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-          <div className='col-md'>
-            <Placeholder className='example-grid-block'>.col-md</Placeholder>
-          </div>
-        </div>
-      </CodeExample>
+        </CodeExample>
+      </div>
     </div>
   ))

--- a/src/styles/libraries/bootstrap-overrides/_grid.scss
+++ b/src/styles/libraries/bootstrap-overrides/_grid.scss
@@ -59,3 +59,15 @@
     padding: 0;
   }
 }
+
+.no-gutters-vertical {
+  margin-top: 0;
+  margin-bottom: 0;
+
+  > .col,
+  > [class^="col-"],
+  > [class*=" col-"] {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}


### PR DESCRIPTION
## Overview
Grid padding isn't always needed, so we'd like to be able to support rolling your own padding options.  This new `.row.no-gutters-vertical` option (which is used on `.row` elements) will remove only the vertical padding between rows.

## Risks
None - not even used yet, new style

## Changes
![image](https://user-images.githubusercontent.com/505670/46701683-66532e00-cbd5-11e8-8439-1bec51cbe1eb.png)

## Issue
https://github.com/yankaindustries/mc-components/issues/224