### PR TITLE
Building new <Modal /> component

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -19,7 +19,7 @@ export default class Modal extends PureComponent {
     children: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.arrayOf(PropTypes.node),
-    ]),
+    ]).isRequired,
     className: PropTypes.string,
     show: PropTypes.bool,
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,72 @@
+import React, { PureComponent } from 'react'
+import { createPortal } from 'react-dom'
+import PropTypes from 'prop-types'
+import cn from 'classnames'
+
+import IconClose from '../Icons/Close'
+
+
+export default class Modal extends PureComponent {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.arrayOf(PropTypes.node),
+    ]),
+    className: PropTypes.string,
+    show: PropTypes.bool,
+
+    onCloseClick: PropTypes.func,
+  }
+
+  onKeyDown = (event) => {
+    if (event.keyCode === 27) {
+      this.close()
+    }
+  }
+
+  close = () => {
+    const {
+      onCloseClick,
+    } = this.props
+
+    if (onCloseClick) {
+      onCloseClick()
+    }
+  }
+
+  render () {
+    const {
+      children,
+      className,
+      show,
+    } = this.props
+
+    if (!show) {
+      return null
+    }
+
+    const classes = cn({
+      [className]: className,
+      'mc-modal': true,
+    })
+
+    return createPortal(
+      <div
+        className={classes}
+        onKeyDown={this.onKeyDown}
+      >
+        <a
+          className='mc-modal__backdrop'
+          onClick={this.close}
+        >
+          <IconClose className='mc-modal__close' />
+        </a>
+
+        <div className='mc-modal__container'>
+          {children}
+        </div>
+      </div>,
+      document.body,
+    )
+  }
+}

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -6,6 +6,14 @@ import cn from 'classnames'
 import IconClose from '../Icons/Close'
 
 
+const ModalContext = React.createContext('modal')
+
+export const {
+  Provider,
+  Consumer,
+} = ModalContext
+
+
 export default class Modal extends PureComponent {
   static propTypes = {
     children: PropTypes.oneOfType([
@@ -20,17 +28,17 @@ export default class Modal extends PureComponent {
 
   onKeyDown = (event) => {
     if (event.keyCode === 27) {
-      this.close()
+      this.close('escape')(event)
     }
   }
 
-  close = () => {
+  close = source => (event) => {
     const {
       onCloseClick,
     } = this.props
 
     if (onCloseClick) {
-      onCloseClick()
+      onCloseClick(source, event)
     }
   }
 
@@ -39,6 +47,8 @@ export default class Modal extends PureComponent {
       children,
       className,
       show,
+
+      onCloseClick,
     } = this.props
 
     if (!show) {
@@ -51,21 +61,30 @@ export default class Modal extends PureComponent {
     })
 
     return createPortal(
-      <div
-        className={classes}
-        onKeyDown={this.onKeyDown}
-      >
-        <a
-          className='mc-modal__backdrop'
-          onClick={this.close}
+      <Provider value={{ close: this.close }}>
+        <div
+          className={classes}
+          onKeyDown={this.onKeyDown}
+          ref={this.container}
         >
-          <IconClose className='mc-modal__close' />
-        </a>
+          <div className='mc-modal__backdrop' />
 
-        <div className='mc-modal__container'>
-          {children}
+          {onCloseClick &&
+            <div
+              className='mc-modal__close'
+              onClick={this.close('close')}
+            >
+              <IconClose />
+            </div>
+          }
+
+          <div className='mc-modal__content-container'>
+            <div className='mc-modal__content-container-inner'>
+              {children}
+            </div>
+          </div>
         </div>
-      </div>,
+      </Provider>,
       document.body,
     )
   }

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -1,0 +1,117 @@
+import React, { Component } from 'react'
+import { storiesOf } from '@storybook/react'
+import { withProps } from '../../utils/addon-props'
+
+import CodeExample from '../../utils/CodeExample'
+
+import Modal from '../Modal'
+import ModalContent from '../ModalContent'
+import Button from '../Button'
+import VideoPlayer from '../VideoPlayer'
+
+
+class ModalExample extends Component {
+  state = {
+    large: false,
+    small: false,
+    full: false,
+  }
+
+  showModal = name => () => {
+    this.setState({
+      [name]: true,
+    })
+  }
+
+  hideModal = name => () => {
+    this.setState({
+      [name]: false,
+    })
+  }
+
+  render () {
+    return (
+      <div className='container'>
+        <div className='example--section'>
+          <h1 className='mc-text-h1'>
+            Modal
+          </h1>
+          <p className='mc-text--muted'>
+            A flexible controlled modal.
+          </p>
+        </div>
+
+        <div className='example--section'>
+          <CodeExample>
+            <div className='row'>
+              <div className='col-sm-auto'>
+                <Button onClick={this.showModal('small')}>
+                  Small
+                </Button>
+
+                <Modal
+                  onCloseClick={this.hideModal('small')}
+                  show={this.state.small}
+                >
+                  <div className='container'>
+                    <div className='row'>
+                      <div className='col-sm-6 offset-sm-3'>
+                        <ModalContent>
+                          <div className='rounded-box'>
+                            <p>Content</p>
+                          </div>
+                        </ModalContent>
+                      </div>
+                    </div>
+                  </div>
+                </Modal>
+              </div>
+
+              <div className='col-sm-auto'>
+                <Button onClick={this.showModal('large')}>
+                  Large
+                </Button>
+
+                <Modal
+                  onCloseClick={this.hideModal('large')}
+                  show={this.state.large}
+                >
+                  <div className='container'>
+                    <ModalContent>
+                      <div className='rounded-box'>
+                        <p>Content</p>
+                      </div>
+                    </ModalContent>
+                  </div>
+                </Modal>
+              </div>
+
+              <div className='col-sm-auto'>
+                <Button onClick={this.showModal('full')}>
+                  Full
+                </Button>
+
+                <Modal
+                  onCloseClick={this.hideModal('full')}
+                  show={this.state.full}
+                >
+                  <div className='container-fluid'>
+                    <ModalContent>
+                      <VideoPlayer hasAutoplay />
+                    </ModalContent>
+                  </div>
+                </Modal>
+              </div>
+            </div>
+          </CodeExample>
+        </div>
+      </div>
+    )
+  }
+}
+
+
+storiesOf('components|Modal', module)
+  .add('Summary', withProps(Modal)(() =>
+    <ModalExample />,
+  ))

--- a/src/components/ModalContent/index.js
+++ b/src/components/ModalContent/index.js
@@ -11,7 +11,7 @@ export default class ModalContent extends PureComponent {
     children: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.arrayOf(PropTypes.node),
-    ]),
+    ]).isRequired,
     className: PropTypes.string,
   }
 

--- a/src/components/ModalContent/index.js
+++ b/src/components/ModalContent/index.js
@@ -2,6 +2,9 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import cn from 'classnames'
 
+import { Consumer } from '../Modal'
+import ClickOutside from '../ClickOutside'
+
 
 export default class ModalContent extends PureComponent {
   static propTypes = {
@@ -12,15 +15,11 @@ export default class ModalContent extends PureComponent {
     className: PropTypes.string,
   }
 
-  constructor (props) {
-    super(props)
-
-    this.content = React.createRef()
-  }
-
   componentDidMount () {
     this.content.current.focus()
   }
+
+  content = React.createRef()
 
   render () {
     const {
@@ -34,13 +33,21 @@ export default class ModalContent extends PureComponent {
     })
 
     return (
-      <div
-        className={classes}
-        ref={this.content}
-        tabIndex='-1'
-      >
-        {children}
-      </div>
+      <Consumer>
+        {({ close }) =>
+          <div
+            className={classes}
+            ref={this.content}
+            tabIndex='-1'
+          >
+            <ClickOutside
+              onClickOutside={close('backdrop')}
+            >
+              {children}
+            </ClickOutside>
+          </div>
+        }
+      </Consumer>
     )
   }
 }

--- a/src/components/ModalContent/index.js
+++ b/src/components/ModalContent/index.js
@@ -1,0 +1,46 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+import cn from 'classnames'
+
+
+export default class ModalContent extends PureComponent {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.arrayOf(PropTypes.node),
+    ]),
+    className: PropTypes.string,
+  }
+
+  constructor (props) {
+    super(props)
+
+    this.content = React.createRef()
+  }
+
+  componentDidMount () {
+    this.content.current.focus()
+  }
+
+  render () {
+    const {
+      children,
+      className,
+    } = this.props
+
+    const classes = cn({
+      [className]: className,
+      'mc-modal__content': true,
+    })
+
+    return (
+      <div
+        className={classes}
+        ref={this.content}
+        tabIndex='-1'
+      >
+        {children}
+      </div>
+    )
+  }
+}

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -1,13 +1,19 @@
 .mc-modal {
-  &__backdrop {
-    @include fade-in-opacity();
+  @include fade-in-opacity();
 
-    position: fixed;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+
+  &__backdrop {
+    position: absolute;
     left: 0;
     top: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba($mc-color-dark, 0.8);
+    background: rgba($mc-color-dark, 0.8);
     z-index: $mc-zindex-modal-backdrop;
   }
 
@@ -16,14 +22,20 @@
     right: 0;
     top: 0;
     margin: 2rem;
+    padding: 1rem;
+    line-height: 1rem;
+    background: rgba($mc-color-dark, 0.5);
+    border-radius: 100%;
     cursor: pointer;
-    z-index: $mc-zindex-modal + 1;
+    z-index: $mc-zindex-modal + 2;
+
+    svg {
+      vertical-align: top;
+    }
   }
 
-  &__container {
-    @include fade-in-opacity();
-
-    position: fixed;
+  &__content-container {
+    position: absolute;
     left: 0;
     top: 0;
     width: 100%;
@@ -31,13 +43,16 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    pointer-events: none;
     z-index: $mc-zindex-modal;
   }
 
-  &__content {
-    pointer-events: auto;
+  &__content-container-inner {
+    flex: 1;
+    max-height: 100vh;
+    overflow: auto;
+  }
 
+  &__content {
     &:focus {
       outline: none;
     }

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -1,0 +1,45 @@
+.mc-modal {
+  &__backdrop {
+    @include fade-in-opacity();
+
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba($mc-color-dark, 0.8);
+    z-index: $mc-zindex-modal-backdrop;
+  }
+
+  &__close {
+    position: absolute;
+    right: 0;
+    top: 0;
+    margin: 2rem;
+    cursor: pointer;
+    z-index: $mc-zindex-modal + 1;
+  }
+
+  &__container {
+    @include fade-in-opacity();
+
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: $mc-zindex-modal;
+  }
+
+  &__content {
+    pointer-events: auto;
+
+    &:focus {
+      outline: none;
+    }
+  }
+}


### PR DESCRIPTION
## Overview
The original Modal component was a little less flexible than what this component library is expected to be, so this is a replacement.  

## Risks
Medium - All modal implementations will need to be replaced.  We are not keeping around the legacy implementation to simplify adoption this time.

## Changes
The new biggest change to the Modal component is that it isn't very concerned with how it looks.  The only decision that has been made is where the close button lives (outside, top right, which I think to be reasonable to expect consistency in), as well as a semi-transparent black background.  Other than that, structural styling is decided by what other components you decide to use.

There are actually two components that are necessary, `Modal` and `ModalContent`.  Below you'll see why we need `ModalContent`.

This is code directly from the story that shows three ways you can (but are not limited to) implement the modal:
<img width="573" alt="screen shot 2018-10-10 at 10 50 44 am" src="https://user-images.githubusercontent.com/249444/46758538-ecc54980-cc81-11e8-8473-39bedf829e6a.png">

The outcome if clicking on all three buttons are as follows:

<img width="923" alt="screen shot 2018-10-10 at 10 49 47 am" src="https://user-images.githubusercontent.com/249444/46758604-1b432480-cc82-11e8-883f-3852bb87fa02.png">
<img width="923" alt="screen shot 2018-10-10 at 10 49 49 am" src="https://user-images.githubusercontent.com/249444/46758608-1d0ce800-cc82-11e8-9370-f7ee81c85b45.png">
<img width="923" alt="screen shot 2018-10-10 at 10 49 54 am" src="https://user-images.githubusercontent.com/249444/46758613-1ed6ab80-cc82-11e8-9ca4-19831cb63f60.png">

You'll see that the content within the `Modal` components are centered (vertically and horizontally) above the modal background layer.  Additionally, you'll notice that the grid system is used to position the content (in these cases, in other cases you can use whatever you like), and then we have the `ModalContent` component. `ModalContent`'s primary use is to designate which part of the modal is structural setup, and which part is actual content.  It is also assists in capturing focus so that users can use the escape key to exit.

The mechanism for showing and hiding the component largely remains the same, although the values are not required.  In the case that you want to display what appears to be a modal without controlling it (faux modal) it supports that as well.

Lastly, there used to be a `ModalPortal` component.  The way this was set up required you to have a mounting point for the modal.  We've removed this, and it simply appends to the modal to `document.body` and doesn't require a mounting point at all.

## Issue
https://masterclass-dev.atlassian.net/browse/WI-69
