### PR TITLE
Adding sitemap link to footer

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -45,7 +45,7 @@ export default class Footer extends PureComponent {
                       rel='noopener noreferrer'
                       href='https://masterclasshelp.zendesk.com/hc/en-us'
                     >
-                      Help Center
+                      Support
                     </a>
                   </li>
 
@@ -69,6 +69,10 @@ export default class Footer extends PureComponent {
 
                   <li className='mc-site-footer__link'>
                     <a href='http://careers.masterclass.com'>Careers</a>
+                  </li>
+
+                  <li className='mc-site-footer__link'>
+                    <a href='/sitemap'>Sitemap</a>
                   </li>
 
                   <p className='mc-site-footer__copyright mc-text-legal mc-text--capitalize'>

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -46,7 +46,7 @@
   }
 }
 
-@media (min-width: $mc-bp-md) {
+@media (min-width: $mc-bp-lg) {
   .mc-site-footer {
     &__logo-footer {
       border: 0;
@@ -75,13 +75,13 @@
     }
 
     &__links {
-      margin: 0 12px;
+      margin: 0 10px;
       border-left: 1px solid rgba($mc-color-light, 0.2);
       border-right: 1px solid rgba($mc-color-light, 0.2);
     }
 
     &__link {
-      padding: 0 8px;
+      padding: 0 5px;
     }
 
     &__copyright {


### PR DESCRIPTION
## Overview
Masterclass footer needs to be updated to support a sitemap link.

https://masterclass-dev.atlassian.net/wiki/spaces/VI/pages/47973549/Create+and+programmatically+update+HTML+and+XML+sitemap?focusedCommentId=52166987#comment-52166987

## Risks
None

## Changes
Adds new link to footer, renames "Help Center" to "Support" to save horizontal space, adjust css to fit one more link on desktop before breakpoint shrinks.

## Issue
https://github.com/yankaindustries/mc-components/issues/247