### PR TITLE
Updating typography to work with seo page and future pages

### DIFF
--- a/src/foundation/type/index.stories.js
+++ b/src/foundation/type/index.stories.js
@@ -74,6 +74,14 @@ storiesOf('foundation|Type', module)
         </div>
 
         <div className='align-items-center example--section'>
+          <h5 className='mc-text-h5'>Readable</h5>
+          <p className='mc-text-intro'>Online classes taught by the world&#39;s greatest minds. Now get
+           unlimited access to all classes.
+          </p>
+          <p className='mc-text--muted mc-text--monospace'>.mc-text-readable</p>
+        </div>
+
+        <div className='align-items-center example--section'>
           <h5 className='mc-text-h5'>Legal</h5>
           <p className='mc-text-legal'>Copyright 2018 MasterClass</p>
           <p className='mc-text--muted mc-text--monospace'>.mc-text-legal</p>

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -5,10 +5,7 @@ html {
 // Referenced as "paragraph 2" in comps
 body {
   background: $mc-color-background;
-  font-family: $mc-font-default;
-  font-size: 12px;
-  line-height: 1.5;
-  font-weight: 400;
+  font: 400 16px/1.5 $mc-font-default;
   color: $mc-color-text;
   letter-spacing: 0.015em;
   font-variant-ligatures: none;
@@ -74,29 +71,34 @@ a {
 }
 
 .mc-text-h1 {
-  font-size: 20px;
+  font-size: 28px;
 }
 
 .mc-text-h2 {
-  font-size: 18px;
+  font-size: 24px;
 }
 
 .mc-text-h3 {
-  font-size: 16px;
+  font-size: 20px;
 }
 
 .mc-text-h4 {
-  font-size: 12px;
+  font-size: 16px;
+  letter-spacing: 0.06em;
 }
 
 .mc-text-h5 {
-  font-size: 10px;
+  font-size: 12px;
+  letter-spacing: 0.06em;
 }
 
-// Referenced as "paragraph 1" in comps
-.mc-text-intro {
-  font-size: 16px;
-  line-height: 26px;
+// 'Readable' for article pages
+// intro as placeholder for intro styles with
+// extra margins / treatment in the future.
+.mc-text-intro,
+.mc-text-readable {
+  font-size: 20px;
+  line-height: 1.5;
   letter-spacing: 0.025em;
   font-weight: 400;
 }
@@ -115,13 +117,11 @@ a {
   .mc-text-d1 { font-size: 32px; }
   .mc-text-d2 { font-size: 24px; }
 
-  .mc-text-h1 { font-size: 24px; }
-  .mc-text-h2 { font-size: 20px; }
-  .mc-text-h3 { font-size: 18px; }
-  .mc-text-h4 { font-size: 14px; }
-  .mc-text-h5 { font-size: 12px; }
-
-  .mc-text-intro { font-size: 20px; }
+  .mc-text-h1 { font-size: 32px; }
+  .mc-text-h2 { font-size: 28px; }
+  .mc-text-h3 { font-size: 24px; }
+  .mc-text-h4 { font-size: 20px; }
+  .mc-text-h5 { font-size: 16px; }
 }
 
 @media (min-width: $mc-bp-lg) {
@@ -129,7 +129,9 @@ a {
   .mc-text-d2 { font-size: 32px; }
   .mc-text-d3 { font-size: 20px; }
 
-  .mc-text-h1 { font-size: 32px; }
-  .mc-text-h2 { font-size: 24px; }
-  .mc-text-h3 { font-size: 20px; }
+  .mc-text-h1 { font-size: 48px; }
+  .mc-text-h2 { font-size: 32px; }
+  .mc-text-h3 { font-size: 28px; }
+  .mc-text-h4 { font-size: 24px; }
+  .mc-text-h5 { font-size: 20px; }
 }

--- a/src/styles/typography/base.scss
+++ b/src/styles/typography/base.scss
@@ -88,7 +88,7 @@ a {
 }
 
 .mc-text-h5 {
-  font-size: 12px;
+  font-size: 16px;
   letter-spacing: 0.06em;
 }
 

--- a/src/styles/typography/modifiers.scss
+++ b/src/styles/typography/modifiers.scss
@@ -7,6 +7,7 @@
 
   // Weight / opacity
   &--bold { font-weight: 600 !important; }
+  &--italic { font-style: italic !important; }
   &--normal { font-weight: 500 !important; }
   &--x-light { font-weight: 300 !important; }
   &--muted { opacity: 0.5 !important; }


### PR DESCRIPTION
## Overview
The new SEO page relies heavily on typography and is the perfect test arena for mc-components typography. While working to build out the page, I adjusted the typography we have in mc-components to work with this page.  This is an ongoing learning experience and we will continue to update type styles in the future, but this is a good starting point.

## Risks
No risk for mc-components, but medium risk for the masterclass repo. We are using existing type styles in a few locations in the masterclass repo (outlined below) - these areas will need to be verified as acceptable before versioning.

## Changes
Type updates - font sizing, responsive type changes, new type headings

## Issue
N/A

## Changes
- Base font size now set to 16px and 1.5 line height
- `h1` changed from `32px` on desktop to `48px`
- `h2` changed from `24px` on desktop to `32px`
- `h3` changed from `20px` on desktop to `28px`
- `h4` changed from `14px` on desktop to `24px`
- `h5` changed from `12px` on desktop to `20px`

Type scales down on a sliding scale among these values: 

`48px, 32px, 24px, 20px, 16px, 12px`

So if `h1` is `48px` on desktop, on tablet it will be `32px`, mobile it will be `24px`.
