### PR TITLE
Having Textarea properly display error when no label exists

### DIFF
--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -12,6 +12,7 @@ import { withProps } from '../../utils/addon-props'
 import InputField from '../InputField'
 import CheckboxField from '../CheckboxField'
 import RadioField from '../RadioField'
+import TextareaField from '../TextareaField'
 import Button from '../Button'
 import Lock from '../Icons/Lock'
 
@@ -63,6 +64,15 @@ const Form = reduxForm({
                     label='Email'
                     type='email'
                     placeholder='john@google.com'
+                  />
+                </div>
+
+                <div className='mc-form-group'>
+                  <Field
+                    component={TextareaField}
+                    name='bio'
+                    label='Tell us about yourself'
+                    placeholder='This is the story of a girl...'
                   />
                 </div>
 
@@ -151,6 +161,16 @@ const Form = reduxForm({
                   label='Email'
                   type='email'
                   placeholder='john@google.com'
+                  inverted
+                />
+              </div>
+
+              <div className='mc-form-group'>
+                <Field
+                  component={TextareaField}
+                  name='bio'
+                  label='Tell us about yourself'
+                  placeholder='This is the story of a girl...'
                   inverted
                 />
               </div>

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -79,7 +79,7 @@ export default class Textarea extends PureComponent {
     const classes = cn({
       'mc-form-textarea': true,
       'mc-form-textarea--focus': focused,
-      'mc-form-textarea--no-label': !label,
+      'mc-form-textarea--no-label': !label && !error,
       'mc-form-textarea--modified': value,
       'mc-form-textarea--invert': inverted,
       'mc-form-textarea--disabled': disabled,

--- a/src/components/TextareaField/index.stories.js
+++ b/src/components/TextareaField/index.stories.js
@@ -19,10 +19,8 @@ const store = createStore(reducer)
 const Form = reduxForm({
   form: 'textarea',
   initialValues: {
-    demo: 'Some Value',
-    'inverted-demo': 'Some Value',
+    bio: 'I am me, of course.',
     error: 'Looks like a problem.',
-    'inverted-error': 'Looks like a problem.',
   },
 })(
   () =>
@@ -44,16 +42,14 @@ const Form = reduxForm({
                     component={TextareaField}
                     name='demo'
                     label='Some Label'
-                    value=''
                   />
                 </div>
 
                 <div className='mc-form-group'>
                   <Field
                     component={TextareaField}
-                    name='value'
+                    name='bio'
                     label='Tell us more about yourself'
-                    value='I like turtles...'
                   />
                 </div>
 
@@ -62,7 +58,7 @@ const Form = reduxForm({
                     component={TextareaField}
                     name='error'
                     label='What have we here?'
-                    error
+                    error='Something is wrong'
                   />
                 </div>
 
@@ -71,7 +67,6 @@ const Form = reduxForm({
                     component={TextareaField}
                     name='disabled'
                     label={'Can\'t touch this'}
-                    value=''
                     disabled
                   />
                 </div>
@@ -84,7 +79,7 @@ const Form = reduxForm({
               <div className='mc-form-group'>
                 <Field
                   component={TextareaField}
-                  name='inverted-demo'
+                  name='demo'
                   label='Some Label'
                   inverted
                 />
@@ -93,9 +88,8 @@ const Form = reduxForm({
               <div className='mc-form-group'>
                 <Field
                   component={TextareaField}
-                  name='inverted-value'
+                  name='bio'
                   label='Tell us more about yourself'
-                  value='I like turtles...'
                   inverted
                 />
               </div>
@@ -103,10 +97,9 @@ const Form = reduxForm({
               <div className='mc-form-group'>
                 <Field
                   component={TextareaField}
-                  name='inverted-error'
+                  name='error'
                   label='What have we here?'
-                  value='Looks like a problem.'
-                  error
+                  error='Something is wrong'
                   inverted
                 />
               </div>
@@ -114,9 +107,8 @@ const Form = reduxForm({
               <div className='mc-form-group'>
                 <Field
                   component={TextareaField}
-                  name='inverted-disabled'
+                  name='disabled'
                   label={'Can\'t touch this'}
-                  value=''
                   disabled
                   inverted
                 />

--- a/src/styles/components/forms/textarea/_default.scss
+++ b/src/styles/components/forms/textarea/_default.scss
@@ -49,42 +49,46 @@ $scrollbarWidth: 7px !default; // Browser scrollbar width
       transform 320ms ease 100ms,
       opacity 320ms ease 100ms;
   }
-}
 
+  // States
+  &:hover {
+    border-color: $mc-color-gray-400;
+  }
 
-// States
-.mc-form-textarea:hover {
-  border-color: $mc-color-gray-400;
-}
+  &--focus,
+  &--modified {
+    // border-color: $mc-color-gray-400;
 
-.mc-form-textarea--focus,
-.mc-form-textarea--modified {
-  border-color: $mc-color-gray-400;
+    .mc-form-textarea {
+      &__textarea {
+        padding: 20px $textarea-padding $textarea-padding;
 
-  .mc-form-textarea {
-    &__textarea {
-      padding: 20px $textarea-padding $textarea-padding;
+        &::placeholder {
+          opacity: 1;
+          transition: opacity 250ms ease 100ms;
+        }
+      }
 
-      &::placeholder {
-        opacity: 1;
-        transition: opacity 250ms ease 100ms;
+      &__label {
+        font-size: 11px;
+        transform: translateY(4px);
+        background: $mc-color-light;
+        width: calc(100% - (2 * #{$textarea-padding}) - #{$scrollbarWidth});
+        transition:
+          font 320ms ease 0ms,
+          transform 320ms ease 0ms;
       }
     }
-
-    &__label {
-      font-size: 11px;
-      transform: translateY(4px);
-      background: $mc-color-light;
-      width: calc(100% - (2 * #{$textarea-padding}) - #{$scrollbarWidth});
-      transition:
-        font 320ms ease 0ms,
-        transform 320ms ease 0ms;
-    }
   }
-}
 
-.mc-form-textarea--modified {
-  .mc-form-textarea__textarea {
-    color: $mc-color-gray-400;
+  &--focus {
+    border-color: $mc-color-gray-400;
+  }
+
+  &--modified {
+
+    .mc-form-textarea__textarea {
+      color: $mc-color-gray-400;
+    }
   }
 }


### PR DESCRIPTION
## Overview
Textareas currently don't show errors if no label value exists.  This is incorrect, and fixed in this PR.  Also, added textarea to form overview in Storyboard.

## Risks
None

## Issue
#267
