### PR TITLE
Fixing Button link styles

### DIFF
--- a/src/components/Button/index.stories.js
+++ b/src/components/Button/index.stories.js
@@ -5,32 +5,8 @@ import { withProps } from '../../utils/addon-props'
 import DocSection from '../../utils/DocSection'
 import PropExample from '../../utils/PropExample'
 import Button from '../Button'
+import FacebookIcon from '../Icons/Facebook'
 
-
-const FacebookIcon = () => (
-  <svg
-    width='22'
-    height='22'
-    viewBox='0 0 22 22'
-    fill='none'
-    xmlns='http://www.w3.org/2000/svg'
-  >
-    <path
-      opacity='0.2'
-      fillRule='evenodd'
-      clipRule='evenodd'
-      d='M0 3.2C0 2.0799 0 1.51984 0.217987 1.09202C0.409734 0.715695 0.715695 0.409734 1.09202 0.217987C1.51984 0 2.0799 0 3.2 0H18.8C19.9201 0 20.4802 0 20.908 0.217987C21.2843 0.409734 21.5903 0.715695 21.782 1.09202C22 1.51984 22 2.0799 22 3.2V18.8C22 19.9201 22 20.4802 21.782 20.908C21.5903 21.2843 21.2843 21.5903 20.908 21.782C20.4802 22 19.9201 22 18.8 22H3.2C2.0799 22 1.51984 22 1.09202 21.782C0.715695 21.5903 0.409734 21.2843 0.217987 20.908C0 20.4802 0 19.9201 0 18.8V3.2Z'
-      fill='black'
-    />
-    <path
-      fillRule='evenodd'
-      clipRule='evenodd'
-      d='M2.91079 3.55442V5.68707H0V8.53061H2.91079V17.7721H5.82157V8.53061H9.02344L9.75113 5.68707H5.82157V3.55442C5.82157 3.12789 6.11265 2.84354 6.54927 2.84354H9.47687V0H6.54927C4.51172 0 2.91079 1.56395 2.91079 3.55442Z'
-      transform='translate(6.37891 2.8252)'
-      fill='white'
-    />
-  </svg>
-)
 
 storiesOf('components|Button', module)
   .add('Button', withProps(Button)(() => (
@@ -41,77 +17,119 @@ storiesOf('components|Button', module)
         <PropExample
           name='default (no properties)'
         >
-          <Button>Default</Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button>Default</Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
           name='secondary | tertiary'
           type='Boolean'
         >
-          <Button secondary>Secondary</Button>
-          <Button tertiary>Tertiary</Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button secondary>Secondary</Button>
+            </div>
+
+            <div className='col-auto'>
+              <Button tertiary>Tertiary</Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
-          name='link | link muted | text'
+          name='link | linkMuted | text'
           type='Boolean'
         >
-          <Button link>Link</Button>
-          <Button linkMuted>Link Muted</Button>
-          <Button text>Text</Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button link>Link</Button>
+            </div>
+            <div className='col-auto'>
+              <Button linkMuted>Link Muted</Button>
+            </div>
+            <div className='col-auto'>
+              <Button text>Text</Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
           name='outline'
           type='Boolean'
         >
-          <Button outline>Outline</Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button outline>Outline</Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
           name='outlineInvert'
           type='Boolean'
         >
-          <Button outlineInvert>Outline - Invert</Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button outlineInvert>Outline - Invert</Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
           name='icon'
           type='Component'
         >
-          <Button
-            className='c-button--facebook'
-            Icon={<FacebookIcon />}
-          >
-            Connected
-          </Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button className='c-button--facebook'>
+                <FacebookIcon />
+                {' '}
+                Get Connected
+              </Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
           name='loading'
           type='Boolean'
         >
-          <Button loading>
-            Button
-          </Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button loading>
+                Button
+              </Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
           name='fullWidth'
           type='Boolean'
         >
-          <Button fullWidth>
-            Button
-          </Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button fullWidth>
+                Button
+              </Button>
+            </div>
+          </div>
         </PropExample>
 
         <PropExample
           name='disabled'
           type='Boolean'
         >
-          <Button disabled>
-            Button disabled
-          </Button>
+          <div className='row'>
+            <div className='col-auto'>
+              <Button disabled>
+                Button disabled
+              </Button>
+            </div>
+          </div>
         </PropExample>
       </DocSection>
     </div>

--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -94,6 +94,8 @@
   &--link-muted {
     position: relative;
     background: none;
+    margin: 12px 24px;
+    padding: 4px 0;
     color: $mc-color-light;
     transition: transform 100ms cubic-bezier(0.25, 0.1, 0.25, 1);
 

--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -23,11 +23,7 @@
   }
 
   &--text {
-    font-weight: 700;
-    font-size: 1.3rem;
-    letter-spacing: 0.15rem;
     color: rgba($mc-color-dark, 0.5);
-    padding: 0;
     background-color: transparent;
 
     &:hover {
@@ -98,9 +94,6 @@
   &--link-muted {
     position: relative;
     background: none;
-    margin: 0 12px;
-    // Reset default mc-btn padding
-    padding: 4px 0;
     color: $mc-color-light;
     transition: transform 100ms cubic-bezier(0.25, 0.1, 0.25, 1);
 


### PR DESCRIPTION
## Overview
Link Buttons did not have the same padding/spacing as regular buttons, making them display oddly when next to each other.  This fixes that.

## Risks
None

## Issue
#242