### PR TITLE
added missing bootstrap fn for generating mc-text--center classes

### DIFF
--- a/src/styles/base/_functions.scss
+++ b/src/styles/base/_functions.scss
@@ -20,6 +20,16 @@
   @return map-get($colors, $key);
 }
 
+// Minimum breakpoint width. Null for the smallest (first) breakpoint.
+//
+//    >> breakpoint-min(sm, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px))
+//    576px
+@function breakpoint-min($name, $breakpoints: $grid-breakpoints) {
+  $min: map-get($breakpoints, $name);
+
+  @return if($min != 0, $min, null);
+}
+
 // Returns a blank string if smallest breakpoint, otherwise returns the name with a dash in front.
 // Useful for making responsive utilities.
 //


### PR DESCRIPTION
## Overview
Bugfix for broken `mc-text--center` classes in 0.8.0. I didn't include `breakpoint-min()` which was causing the class to be generated as `mc-text-xs--center`