### PR TITLE
minimizing form group margin, 32px is way too big

### DIFF
--- a/src/styles/components/forms/_structure.scss
+++ b/src/styles/components/forms/_structure.scss
@@ -25,14 +25,6 @@
   @media (min-width: $mc-bp-md) {
     padding-bottom: $grid-gutter-width-md;
   }
-
-  @media (min-width: $mc-bp-lg) {
-    padding-bottom: $grid-gutter-width-lg;
-  }
-
-  @media (min-width: $mc-bp-xl) {
-    padding-bottom: $grid-gutter-width-xl;
-  }
 }
 
 .mc-form-help {


### PR DESCRIPTION
## Overview
`.form-group` bottom margin was set to the same value as the grid gutter.  on larger screens, this value is 32px, but is way too large.  so we stop the growth at medium, 16px.

## Risks
None

## Changes
![screen shot 2018-11-02 at 3 32 26 pm](https://user-images.githubusercontent.com/249444/47943698-89ab8900-deb4-11e8-9b3b-d804328366cc.png)

![screen shot 2018-11-02 at 3 32 12 pm](https://user-images.githubusercontent.com/249444/47943694-84e6d500-deb4-11e8-9f5b-52dc7b2695d6.png)
