### PR TITLE
Scope beta stuff to beta pages

### DIFF
--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -1,5 +1,5 @@
 html {
-  font-size: 16px;
+  font-size: 62.5%;
 }
 
 body {

--- a/src/styles/typography/_beta.scss
+++ b/src/styles/typography/_beta.scss
@@ -10,8 +10,13 @@ $max: 7 !default;
   @return $level * $scale * $factor / $rem * 1rem;
 }
 
-html {
+// this should be on html
+.mc-beta {
   font-size: 14px;
+
+  body {
+    font-size: step(4);
+  }
 
   @media (min-width: $mc-bp-md) {
     font-size: 15px;
@@ -20,10 +25,6 @@ html {
   @media (min-width: $mc-bp-lg) {
     font-size: 16px;
   }
-}
-
-body {
-  font-size: step(4);
 }
 
 .mcb-text {


### PR DESCRIPTION
## Overview
Beta typography needs to be scoped to beta pages only

## Risks
Low, increasing specificity to beta stuffs

## Changes
Prevents beta typography changes from bleeding into production stylesheets

## Issue
N/A