### PR TITLE
Invert updates

### DIFF
--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -34,102 +34,6 @@ const Form = reduxForm({
             <div className='col-sm-6'>
               <h5 className='mc-text-h5'>Default</h5>
 
-              <div className='rounded-box'>
-                <div className='mc-form-group'>
-                  <div className='row'>
-                    <div className='col-sm-6'>
-                      <Field
-                        component={InputField}
-                        name='firstName'
-                        label='First name'
-                        placeholder='John'
-                      />
-                    </div>
-
-                    <div className='col-sm-6'>
-                      <Field
-                        component={InputField}
-                        name='lastName'
-                        label='Last name'
-                        placeholder='Doe'
-                      />
-                    </div>
-                  </div>
-                </div>
-
-                <div className='mc-form-group'>
-                  <Field
-                    component={InputField}
-                    name='email'
-                    label='Email'
-                    type='email'
-                    placeholder='john@google.com'
-                  />
-                </div>
-
-                <div className='mc-form-group'>
-                  <Field
-                    component={TextareaField}
-                    name='bio'
-                    label='Tell us about yourself'
-                    placeholder='This is the story of a girl...'
-                  />
-                </div>
-
-                <div className='mc-form-group'>
-                  <Field
-                    component={RadioField}
-                    name='billing'
-                    option='yearly'
-                    label='Bill me yearly ($180)'
-                  />
-
-                  <Field
-                    component={RadioField}
-                    name='billing'
-                    option='monthly'
-                    label='Bill me monthly ($20)'
-                  />
-                </div>
-
-                <div className='mc-form-group'>
-                  <Field
-                    component={InputField}
-                    name='password'
-                    type='password'
-                    placeholder='Password'
-                    help='Must be at least 8 characters'
-                    prepend={<Lock />}
-                  />
-                </div>
-
-                <div className='mc-form-group'>
-                  <Field
-                    component={InputField}
-                    name='confirm-password'
-                    type='password'
-                    placeholder='Confirm Password'
-                    prepend={<Lock />}
-                  />
-                </div>
-
-                <div className='mc-form-group'>
-                  <Field
-                    component={CheckboxField}
-                    name='terms'
-                    label='I agree to the terms'
-                  />
-                </div>
-
-                <Button fullWidth>
-                  Register
-                </Button>
-              </div>
-            </div>
-
-            <div className='col-sm-6'>
-              <h5 className='mc-text-h5'>Inverted</h5>
-
               <div className='mc-form-group'>
                 <div className='row'>
                   <div className='col-sm-6'>
@@ -138,7 +42,6 @@ const Form = reduxForm({
                       name='firstName'
                       label='First name'
                       placeholder='John'
-                      inverted
                     />
                   </div>
 
@@ -148,7 +51,6 @@ const Form = reduxForm({
                       name='lastName'
                       label='Last name'
                       placeholder='Doe'
-                      inverted
                     />
                   </div>
                 </div>
@@ -161,7 +63,6 @@ const Form = reduxForm({
                   label='Email'
                   type='email'
                   placeholder='john@google.com'
-                  inverted
                 />
               </div>
 
@@ -171,7 +72,6 @@ const Form = reduxForm({
                   name='bio'
                   label='Tell us about yourself'
                   placeholder='This is the story of a girl...'
-                  inverted
                 />
               </div>
 
@@ -181,7 +81,6 @@ const Form = reduxForm({
                   name='billing'
                   option='yearly'
                   label='Bill me yearly ($180)'
-                  inverted
                 />
 
                 <Field
@@ -189,7 +88,6 @@ const Form = reduxForm({
                   name='billing'
                   option='monthly'
                   label='Bill me monthly ($20)'
-                  inverted
                 />
               </div>
 
@@ -201,7 +99,6 @@ const Form = reduxForm({
                   placeholder='Password'
                   help='Must be at least 8 characters'
                   prepend={<Lock />}
-                  inverted
                 />
               </div>
 
@@ -212,7 +109,6 @@ const Form = reduxForm({
                   type='password'
                   placeholder='Confirm Password'
                   prepend={<Lock />}
-                  inverted
                 />
               </div>
 
@@ -221,13 +117,117 @@ const Form = reduxForm({
                   component={CheckboxField}
                   name='terms'
                   label='I agree to the terms'
-                  inverted
                 />
               </div>
 
               <Button fullWidth>
                 Register
               </Button>
+            </div>
+
+            <div className='col-sm-6 mc--invert'>
+              <h5 className='mc-text-h5'>Inverted</h5>
+              <div className='rounded-box'>
+
+                <div className='mc-form-group'>
+                  <div className='row'>
+                    <div className='col-sm-6'>
+                      <Field
+                        component={InputField}
+                        name='firstName'
+                        label='First name'
+                        placeholder='John'
+                        inverted
+                      />
+                    </div>
+
+                    <div className='col-sm-6'>
+                      <Field
+                        component={InputField}
+                        name='lastName'
+                        label='Last name'
+                        placeholder='Doe'
+                        inverted
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                <div className='mc-form-group'>
+                  <Field
+                    component={InputField}
+                    name='email'
+                    label='Email'
+                    type='email'
+                    placeholder='john@google.com'
+                    inverted
+                  />
+                </div>
+
+                <div className='mc-form-group'>
+                  <Field
+                    component={TextareaField}
+                    name='bio'
+                    label='Tell us about yourself'
+                    placeholder='This is the story of a girl...'
+                    inverted
+                  />
+                </div>
+
+                <div className='mc-form-group'>
+                  <Field
+                    component={RadioField}
+                    name='billing'
+                    option='yearly'
+                    label='Bill me yearly ($180)'
+                    inverted
+                  />
+
+                  <Field
+                    component={RadioField}
+                    name='billing'
+                    option='monthly'
+                    label='Bill me monthly ($20)'
+                    inverted
+                  />
+                </div>
+
+                <div className='mc-form-group'>
+                  <Field
+                    component={InputField}
+                    name='password'
+                    type='password'
+                    placeholder='Password'
+                    help='Must be at least 8 characters'
+                    prepend={<Lock />}
+                    inverted
+                  />
+                </div>
+
+                <div className='mc-form-group'>
+                  <Field
+                    component={InputField}
+                    name='confirm-password'
+                    type='password'
+                    placeholder='Confirm Password'
+                    prepend={<Lock />}
+                    inverted
+                  />
+                </div>
+
+                <div className='mc-form-group'>
+                  <Field
+                    component={CheckboxField}
+                    name='terms'
+                    label='I agree to the terms'
+                    inverted
+                  />
+                </div>
+
+                <Button fullWidth>
+                  Register
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/InputField/index.stories.js
+++ b/src/components/InputField/index.stories.js
@@ -37,8 +37,104 @@ const Form = reduxForm({
           <div className='row'>
             <div className='col-sm-6'>
               <h5 className='mc-text-h5'>Default</h5>
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='color'
+                  label='What is your favorite color?'
+                  placeholder='Red, orange, yellow, green, blue, violet, or something else?'
+                />
+              </div>
 
-              <div className='rounded-box'>
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='best'
+                  label='Who sang it best?'
+                  placeholder='Madonna or Britney?'
+                />
+              </div>
+
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='prepend'
+                  placeholder='Search'
+                  prepend={<MagnifyingGlass />}
+                />
+              </div>
+
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='prepend-password'
+                  type='password'
+                  placeholder='Password'
+                  help='You have a secret'
+                  prepend={<Lock />}
+                />
+              </div>
+
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='append'
+                  label='Field with appended icon'
+                  placeholder='Hint: It is a close icon!'
+                  append={<Close />}
+                />
+              </div>
+
+              <hr />
+
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='error'
+                  label='Error example'
+                  placeholder='Try to fix it?'
+                  error
+                />
+              </div>
+
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='fix-it'
+                  label='There might be a problem...'
+                  placeholder='Try to fix it?'
+                  error
+                />
+              </div>
+
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='password-error'
+                  type='password'
+                  label='Incorrect Password'
+                  placeholder='Password'
+                  prepend={<Lock />}
+                  error
+                />
+              </div>
+
+              <hr />
+
+              <div className='mc-form-group'>
+                <Field
+                  component={InputField}
+                  name='disabled'
+                  label='Disabled field'
+                  placeholder='Not clickable!'
+                  disabled
+                />
+              </div>
+            </div>
+
+            <div className='col-sm-6'>
+              <h5 className='mc-text-h5'>Inverted</h5>
+              <div className='rounded-box mc--invert'>
                 <div className='mc-form-group'>
                   <Field
                     component={InputField}
@@ -132,113 +228,6 @@ const Form = reduxForm({
                     disabled
                   />
                 </div>
-              </div>
-            </div>
-
-            <div className='col-sm-6'>
-              <h5 className='mc-text-h5'>Inverted</h5>
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='color'
-                  label='What is your favorite color?'
-                  placeholder='Red, orange, yellow, green, blue, violet, or something else?'
-                  inverted
-                />
-              </div>
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='best'
-                  label='Who sang it best?'
-                  placeholder='Madonna or Britney?'
-                  inverted
-                />
-              </div>
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='prepend'
-                  placeholder='Search'
-                  prepend={<MagnifyingGlass />}
-                  inverted
-                />
-              </div>
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='prepend-password'
-                  type='password'
-                  placeholder='Password'
-                  help='You have a secret'
-                  prepend={<Lock />}
-                  inverted
-                />
-              </div>
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='append'
-                  label='Field with appended icon'
-                  placeholder='Hint: It is a close icon!'
-                  append={<Close />}
-                  inverted
-                />
-              </div>
-
-              <hr />
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='error'
-                  label='Error example'
-                  placeholder='Try to fix it?'
-                  inverted
-                  error
-                />
-              </div>
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='fix-it'
-                  label='There might be a problem...'
-                  placeholder='Try to fix it?'
-                  inverted
-                  error
-                />
-              </div>
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='password-error'
-                  type='password'
-                  label='Incorrect Password'
-                  placeholder='Password'
-                  prepend={<Lock />}
-                  inverted
-                  error
-                />
-              </div>
-
-              <hr />
-
-              <div className='mc-form-group'>
-                <Field
-                  component={InputField}
-                  name='disabled'
-                  label='Disabled field'
-                  placeholder='Not clickable!'
-                  inverted
-                  disabled
-                />
               </div>
             </div>
           </div>

--- a/src/styles/components/forms/checkbox/_default.scss
+++ b/src/styles/components/forms/checkbox/_default.scss
@@ -5,7 +5,7 @@
 
   &__fauxbox {
     position: relative;
-    background: rgba($mc-color-tertiary, 0.2);
+    background: $mc-color-gray-300;
     width: 20px;
     height: 20px;
     border-radius: 4px;

--- a/src/styles/components/forms/checkbox/_modifiers.scss
+++ b/src/styles/components/forms/checkbox/_modifiers.scss
@@ -2,7 +2,7 @@
 .mc-input-checkbox--invert {
   .mc-input-checkbox {
     &__fauxbox {
-      background: $mc-color-gray-300;
+      background: rgba($mc-color-tertiary, 0.2);
     }
   }
 
@@ -10,7 +10,7 @@
   &.mc-input-checkbox:hover,
   &.mc-input-checkbox--hover {
     .mc-input-checkbox__fauxbox {
-      background: $mc-color-gray-400;
+      background: rgba($mc-color-gray-400, 0.4);
     }
   }
 

--- a/src/styles/components/forms/checkbox/_states.scss
+++ b/src/styles/components/forms/checkbox/_states.scss
@@ -6,7 +6,7 @@
   &--hover {
     // default
     .mc-input-checkbox__fauxbox {
-      background: rgba($mc-color-gray-400, 0.4);
+      background: $mc-color-gray-400;
     }
   }
 

--- a/src/styles/components/forms/input/_default.scss
+++ b/src/styles/components/forms/input/_default.scss
@@ -1,8 +1,8 @@
 .mc-form-input {
   display: flex;
   align-items: center;
-  border: 1px solid $mc-color-gray-600;
-  background: transparent;
+  border: 1px solid $mc-color-gray-300;
+  background: $mc-color-gray-200;
   border-radius: 4px;
   width: 100%;
   color: $mc-color-gray-500;
@@ -19,6 +19,7 @@
 
     input {
       font-family: $mc-font-default;
+      color: $mc-color-gray-600;
       background: none;
       outline: none;
       border: 0;
@@ -43,8 +44,8 @@
   }
 
   &--focus {
+    color: $mc-color-gray-600;
     border-color: $mc-color-gray-400;
-    color: $mc-color-gray-100;
   }
 
   &--focus,

--- a/src/styles/components/forms/input/_modifiers.scss
+++ b/src/styles/components/forms/input/_modifiers.scss
@@ -15,34 +15,6 @@
   }
 }
 
-// Inverted styles
-.mc-form-input--invert {
-  border: 1px solid $mc-color-gray-300;
-  background: $mc-color-gray-200;
-
-  &.mc-form-input--focus {
-    color: $mc-color-gray-600;
-    border-color: $mc-color-gray-400;
-  }
-
-  .mc-form-input {
-    &__input {
-      input {
-        color: $mc-color-gray-600;
-      }
-    }
-  }
-
-  &.mc-form-input--disabled {
-    background: $mc-color-gray-100;
-    border-color: $mc-color-gray-100;
-
-    &:hover {
-      border-color: $mc-color-gray-100;
-    }
-  }
-}
-
 // Error states
 .mc-form-input--error {
   background: none;
@@ -74,12 +46,40 @@
 
 // disabled state
 .mc-form-input--disabled {
-  background: $mc-color-gray-600;
+  background: $mc-color-gray-100;
+  border-color: $mc-color-gray-100;
 
   // disable cursor
   * { cursor: not-allowed; }
 
   &:hover {
-    border-color: $mc-color-gray-600;
+    border-color: $mc-color-gray-100;
+  }
+}
+
+// Inverted styles
+@at-root .mc--invert .mc-form-input {
+  border: 1px solid $mc-color-gray-600;
+  background: transparent;
+
+  &.mc-form-input--focus {
+    border-color: $mc-color-gray-400;
+    color: $mc-color-gray-100;
+  }
+
+  .mc-form-input {
+    &__input {
+      input {
+        color: $mc-color-gray-200;
+      }
+    }
+  }
+
+  &.mc-form-input--disabled {
+    background: $mc-color-gray-600;
+
+    &:hover {
+      border-color: $mc-color-gray-600;
+    }
   }
 }

--- a/src/styles/components/forms/radio/_default.scss
+++ b/src/styles/components/forms/radio/_default.scss
@@ -12,7 +12,7 @@
     border-radius: 20px;
     width: 20px;
     height: 20px;
-    background: rgba($mc-color-tertiary, 0.2);
+    background: $mc-color-gray-300;
     cursor: pointer;
     margin-right: 16px;
 
@@ -23,7 +23,7 @@
       width: 10px;
       height: 10px;
       border-radius: 10px;
-      background: $mc-color-dark;
+      background: $mc-color-light;
       transform: scale(0.5);
       opacity: 0;
       transition:

--- a/src/styles/components/forms/radio/_modifiers.scss
+++ b/src/styles/components/forms/radio/_modifiers.scss
@@ -1,12 +1,10 @@
-.mc-input-radio--invert {
-  // color: $mc-color-light;
-
+@at-root .mc--invert .mc-input-radio {
   .mc-input-radio {
     &__button {
-      background: $mc-color-gray-300;
+      background: rgba($mc-color-tertiary, 0.2);
 
       &:after {
-        background: $mc-color-light;
+        background: $mc-color-dark;
       }
     }
   }

--- a/src/styles/components/forms/textarea/_default.scss
+++ b/src/styles/components/forms/textarea/_default.scss
@@ -4,8 +4,8 @@ $scrollbarWidth: 7px !default; // Browser scrollbar width
 .mc-form-textarea {
   position: relative;
   width: 100%;
-  background: $mc-color-light;
-  border: 1px solid $mc-color-gray-600;
+  background: $mc-color-dark;
+  border-color: $mc-color-gray-300;
   border-radius: 4px;
   font-size: 15px;
   line-height: 1.5;
@@ -58,8 +58,6 @@ $scrollbarWidth: 7px !default; // Browser scrollbar width
 
   &--focus,
   &--modified {
-    // border-color: $mc-color-gray-400;
-
     .mc-form-textarea {
       &__textarea {
         padding: 20px $textarea-padding $textarea-padding;
@@ -73,7 +71,6 @@ $scrollbarWidth: 7px !default; // Browser scrollbar width
       &__label {
         font-size: 11px;
         transform: translateY(4px);
-        background: $mc-color-light;
         width: calc(100% - (2 * #{$textarea-padding}) - #{$scrollbarWidth});
         transition:
           font 320ms ease 0ms,
@@ -87,9 +84,8 @@ $scrollbarWidth: 7px !default; // Browser scrollbar width
   }
 
   &--modified {
-
     .mc-form-textarea__textarea {
-      color: $mc-color-gray-400;
+      color: $mc-color-light;
     }
   }
 }

--- a/src/styles/components/forms/textarea/_modifiers.scss
+++ b/src/styles/components/forms/textarea/_modifiers.scss
@@ -13,17 +13,13 @@
   }
 }
 
-.mc-form-textarea--invert {
-  background: $mc-color-dark;
-  border-color: $mc-color-gray-300;
+@at-root .mc--invert .mc-form-textarea {
+  background: $mc-color-light;
+  border: 1px solid $mc-color-gray-600;
 
   .mc-form-textarea {
     &__textarea {
-      color: $mc-color-light;
-    }
-
-    &__label {
-      background: $mc-color-dark;
+      color: $mc-color-gray-200;
     }
   }
 }

--- a/src/styles/typography/_modifiers.scss
+++ b/src/styles/typography/_modifiers.scss
@@ -17,7 +17,7 @@
   &--airy { letter-spacing: 0.24em !important; }
 
   // Colors
-  &--invert { color: $mc-color-dark; }
+  @at-root .mc--invert & { color: $mc-color-dark; }
   &--twitter { color: $mc-color-twitter; }
   &--facebook { color: $mc-color-facebook; }
 


### PR DESCRIPTION
# DO NOT MERGE

## Overview
We have moved from having the `--invert` modifier on each element type to instead wrapping elements at the container level with `mc--invert` instead. This PR adapts those changes, and will need to have components / style classes updated in the main masterclass repo.

### Classes updated
The following classes have been removed from the code base.  The proper way to introduce inverted styles is to add a css class of `mc--invert` to the parent wrapper.
  - mc-form-textarea--invert
  - mc-input-checkbox--invert
  - mc-text--invert
  - mc-form-input--invert
  - mc-input-radio--invert
The form invert behavior has also changed. Forms were initially built assuming a white background as the default, with a black background as being invert. To remain consistent with the rest of the invert behaviors, forms will now default to assuming they're on a black background, and the invert styles will be for use on a white background.

## Risks
High.

## Changes
No visible changes as long as classes are switched over properly.

## Issue
https://github.com/yankaindustries/mc-components/issues/275
