### PR TITLE
Updating underline styles for button link types

### DIFF
--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -112,14 +112,17 @@
       &:after {
         position: absolute;
         bottom: -4px;
-        right: 0;
+        left: 0;
         content: "";
         display: block;
-        width: 0;
+        width: 100%;
         height: 1px;
+        pointer-events: none;
         background: $mc-color-light;
+        opacity: 0;
+        transform: translateY(4px);
         transition:
-          width 250ms cubic-bezier(0.25, 0.1, 0.25, 1),
+          transform 250ms cubic-bezier(0.25, 0.1, 0.25, 1),
           opacity 250ms cubic-bezier(0.25, 0.1, 0.25, 1);
       }
     }
@@ -130,9 +133,8 @@
 
       span {
         &:after {
-          width: 100%;
-          left: 0;
-          right: auto;
+          transform: translateY(0);
+          opacity: 1;
         }
       }
     }


### PR DESCRIPTION
## Overview
Design is not a fan of the underline style used for the "link" button type.  The style was originally pulled from the login link at the top right of the logged out homepage, but they've said it's not a style (in terms of animation) that they'd like to use, so this PR removes that animation type from button links.

## Risks
None, design is approved

## Changes
Removes left to right underline animation, replaces with simpler animation.

## Issue
https://github.com/yankaindustries/mc-components/issues/285