### PR TITLE
No transitional, just opacity

### DIFF
--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -120,10 +120,7 @@
         pointer-events: none;
         background: $mc-color-light;
         opacity: 0;
-        transform: translateY(4px);
-        transition:
-          transform 250ms cubic-bezier(0.25, 0.1, 0.25, 1),
-          opacity 250ms cubic-bezier(0.25, 0.1, 0.25, 1);
+        transition: opacity 250ms cubic-bezier(0.25, 0.1, 0.25, 1);
       }
     }
 
@@ -133,7 +130,6 @@
 
       span {
         &:after {
-          transform: translateY(0);
           opacity: 1;
         }
       }


### PR DESCRIPTION
## Overview
Slight revision to previous animation change to underlines on button link styles. I assumed incorrectly that some animation would be acceptable, it was not :( Updating to simply be opacity on button links moving forward

## Risks
None, approved by design

## Changes
Underlines simply fade in and out on hover

## Issue
https://github.com/yankaindustries/mc-components/issues/285
