### PR TITLE
Don't show the error label if the input wasn't touched

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -121,7 +121,7 @@ export default class Input extends PureComponent {
                 htmlFor={name}
                 className='mc-form-input__label'
               >
-                {error || label}
+                {(touched && error) || label}
               </label>
             }
           </div>


### PR DESCRIPTION
## Overview
Show the label when the input wasn't touched

## Risks
None

## Changes
<How does this PR affect existing components? Please show screenshots or GIFs>

## Issue
Resolves #292 
