### PR TITLE
Adding dots to carousel

### DIFF
--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -72,6 +72,7 @@ export default class Carousel extends PureComponent {
     children: PropTypes.node,
     className: PropTypes.string,
     controls: PropTypes.bool,
+    dots: PropTypes.bool,
     fadeEdges: PropTypes.bool,
     focusOnSelect: PropTypes.bool,
     sliderRef: PropTypes.func,
@@ -86,6 +87,7 @@ export default class Carousel extends PureComponent {
     autoPlay: false,
     centered: false,
     controls: false,
+    dots: false,
     fadeEdges: false,
     focusOnSelect: false,
     loop: false,
@@ -102,6 +104,7 @@ export default class Carousel extends PureComponent {
       className,
       centered,
       controls,
+      dots,
       fadeEdges,
       loop,
       sliderRef,
@@ -149,6 +152,7 @@ export default class Carousel extends PureComponent {
           slidesToScroll={scrollCount}
           slidesToShow={showCount}
           infinite={loop}
+          dots={dots}
           {...arrows}
           {...restProps}
         >

--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -72,7 +72,6 @@ export default class Carousel extends PureComponent {
     children: PropTypes.node,
     className: PropTypes.string,
     controls: PropTypes.bool,
-    dots: PropTypes.bool,
     fadeEdges: PropTypes.bool,
     focusOnSelect: PropTypes.bool,
     sliderRef: PropTypes.func,
@@ -87,7 +86,6 @@ export default class Carousel extends PureComponent {
     autoPlay: false,
     centered: false,
     controls: false,
-    dots: false,
     fadeEdges: false,
     focusOnSelect: false,
     loop: false,
@@ -104,7 +102,6 @@ export default class Carousel extends PureComponent {
       className,
       centered,
       controls,
-      dots,
       fadeEdges,
       loop,
       sliderRef,
@@ -152,7 +149,6 @@ export default class Carousel extends PureComponent {
           slidesToScroll={scrollCount}
           slidesToShow={showCount}
           infinite={loop}
-          dots={dots}
           {...arrows}
           {...restProps}
         >

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -102,7 +102,7 @@ storiesOf('components|Carousel', module)
           name='centered'
           type='Boolean'
         >
-          <Carousel centered>
+          <Carousel centered dots>
             {items.map((item, key) => (
               <div key={key} className='col-auto'>
                 <Tile key={item.id}>

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -102,7 +102,27 @@ storiesOf('components|Carousel', module)
           name='centered'
           type='Boolean'
         >
-          <Carousel centered dots>
+          <Carousel centered>
+            {items.map((item, key) => (
+              <div key={key} className='col-auto'>
+                <Tile key={item.id}>
+                  <TileImage imageUrl={item.thumbnail} />
+                  <TileOverlay />
+                  <TileCaption
+                    title={item.instructor}
+                    subtitle={`Teaches ${item.teaches}`}
+                  />
+                </Tile>
+              </div>
+            ))}
+          </Carousel>
+        </PropExample>
+
+        <PropExample
+          name='dots'
+          type='Boolean'
+        >
+          <Carousel dots>
             {items.map((item, key) => (
               <div key={key} className='col-auto'>
                 <Tile key={item.id}>

--- a/src/styles/components/_carousel.scss
+++ b/src/styles/components/_carousel.scss
@@ -1,41 +1,41 @@
 $mc-carousel-centered-padding: 100px !default;
 
-.slick-dots {
-  /* stylelint-disable */
-  display: flex !important;
-  /* stylelint-enable */
-  justify-content: center;
-  padding: 25px 0 0;
+.mc-carousel {
+  position: relative;
 
-  li {
-    line-height: 0;
-  }
+  .slick-dots {
+    /* stylelint-disable */
+    display: flex !important;
+    /* stylelint-enable */
+    justify-content: center;
+    padding: 25px 0 0;
 
-  button {
-    background: $mc-color-gray-400;
-    width: 6px;
-    height: 6px;
-    border-radius: 6px;
-    margin: 0 4px;
-    overflow: hidden;
-    text-indent: 9999em;
-    cursor: pointer;
-    transition: background 250ms ease;
-    outline: 0;
+    li {
+      line-height: 0;
+    }
 
-    &:hover {
-      background: $mc-color-gray-300;
+    button {
+      background: $mc-color-gray-400;
+      width: 6px;
+      height: 6px;
+      border-radius: 6px;
+      margin: 0 4px;
+      overflow: hidden;
+      text-indent: 9999em;
+      cursor: pointer;
+      transition: background 250ms ease;
+      outline: 0;
+
+      &:hover {
+        background: $mc-color-gray-300;
+      }
+    }
+
+    .slick-active button {
+      background: $mc-color-gray-500;
     }
   }
 
-  .slick-active button {
-    background: $mc-color-gray-500;
-  }
-}
-
-
-.mc-carousel {
-  position: relative;
 
   &__container {
     margin: 0 calc(50% - 50vw);

--- a/src/styles/components/_carousel.scss
+++ b/src/styles/components/_carousel.scss
@@ -5,7 +5,7 @@ $mc-carousel-centered-padding: 100px !default;
   display: flex !important;
   /* stylelint-enable */
   justify-content: center;
-  padding: 25px 0;
+  padding: 25px 0 0;
 
   li {
     line-height: 0;

--- a/src/styles/components/_carousel.scss
+++ b/src/styles/components/_carousel.scss
@@ -1,5 +1,39 @@
 $mc-carousel-centered-padding: 100px !default;
 
+.slick-dots {
+  /* stylelint-disable */
+  display: flex !important;
+  /* stylelint-enable */
+  justify-content: center;
+  padding: 25px 0;
+
+  li {
+    line-height: 0;
+  }
+
+  button {
+    background: $mc-color-gray-400;
+    width: 6px;
+    height: 6px;
+    border-radius: 6px;
+    margin: 0 4px;
+    overflow: hidden;
+    text-indent: 9999em;
+    cursor: pointer;
+    transition: background 250ms ease;
+    outline: 0;
+
+    &:hover {
+      background: $mc-color-gray-300;
+    }
+  }
+
+  .slick-active button {
+    background: $mc-color-gray-500;
+  }
+}
+
+
 .mc-carousel {
   position: relative;
 

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -40,6 +40,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    // Hide excess tile overlay
+    overflow: hidden;
   }
 
   &--naked {
@@ -153,7 +155,9 @@
 }
 
 .mc-tile-overlay {
-  transform: scale(1);
+  // 1.01 guarantees extra coverage in case of
+  // pixel rounding down to be too small
+  transform: scale(1.01);
 
   &--gradient-bottom {
     background:

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -40,8 +40,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    // Hide excess tile overlay
-    overflow: hidden;
   }
 
   &--naked {

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -153,7 +153,7 @@
 }
 
 .mc-tile-overlay {
-  transform: scale(1.01);
+  transform: scale(1);
 
   &--gradient-bottom {
     background:


### PR DESCRIPTION
## Overview
Slick slider has a "dots" option to add thumbnail dots to a slider. This PR adds some styles to override their default, as well as passes along the option as a boolean.

## Risks
None...I don't know if this is the right way to do this, or if I should pass a bunch of options, including custom markup like the `arrows` example. Will have @jstnjns weigh in on this.

## Changes
![dots](https://user-images.githubusercontent.com/505670/48518931-0547f700-e820-11e8-8345-0e4393772b38.gif)

## Issue
N/A


