### PR TITLE
Updating letter spacing for consistency

### DIFF
--- a/src/styles/components/buttons/_button.scss
+++ b/src/styles/components/buttons/_button.scss
@@ -8,7 +8,7 @@
   font-size: 12px;
   font-weight: 700;
   line-height: 1.25;
-  letter-spacing: 0.144em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   border-radius: 4px;
   color: $mc-color-light;


### PR DESCRIPTION
## Overview
Figma comps were showing 12% for letter spacing, which was different than our original values - I think I forgot to update the letter spacing values when the buttons were finalized.

## Risks
Low

## Changes
![letterspacing](https://user-images.githubusercontent.com/505670/48572960-c0739d00-e8bf-11e8-901c-f46a2e27595a.gif)

## Issue
N/A
