### PR TITLE
Temporarily removing fadeEdges until needed, implementation is flawed

### DIFF
--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -138,25 +138,23 @@ export default class Carousel extends PureComponent {
       }
 
     return (
-      <div className='mc-carousel__container'>
-        <Slider
-          autoplay={autoPlay}
-          className={classes}
-          centerMode={centered || fadeEdges}
-          centerPadding={fadeEdges ? CENTERED_PADDING : 0}
-          fade={transition === TRANSITION_FADE}
-          ref={sliderRef}
-          slidesToScroll={scrollCount}
-          slidesToShow={showCount}
-          infinite={loop}
-          {...arrows}
-          {...restProps}
-        >
-          {Children.map(children, child => (
-            <Slide>{child}</Slide>
-          ))}
-        </Slider>
-      </div>
+      <Slider
+        autoplay={autoPlay}
+        className={classes}
+        centerMode={centered || fadeEdges}
+        centerPadding={fadeEdges ? CENTERED_PADDING : 0}
+        fade={transition === TRANSITION_FADE}
+        ref={sliderRef}
+        slidesToScroll={scrollCount}
+        slidesToShow={showCount}
+        infinite={loop}
+        {...arrows}
+        {...restProps}
+      >
+        {Children.map(children, child => (
+          <Slide>{child}</Slide>
+        ))}
+      </Slider>
     )
   }
 }

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -159,26 +159,6 @@ storiesOf('components|Carousel', module)
         </PropExample>
 
         <PropExample
-          name='fadeEdges'
-          type='Boolean'
-        >
-          <Carousel fadeEdges>
-            {items.map((item, key) => (
-              <div key={key} className='col-auto'>
-                <Tile key={item.id}>
-                  <TileImage imageUrl={item.thumbnail} />
-                  <TileOverlay />
-                  <TileCaption
-                    title={item.instructor}
-                    subtitle={`Teaches ${item.teaches}`}
-                  />
-                </Tile>
-              </div>
-            ))}
-          </Carousel>
-        </PropExample>
-
-        <PropExample
           name='focusOnSelect'
           type='Boolean'
         >

--- a/src/styles/components/_carousel.scss
+++ b/src/styles/components/_carousel.scss
@@ -38,9 +38,9 @@ $mc-carousel-centered-padding: 100px !default;
 
 
   &__container {
-    margin: 0 calc(50% - 50vw);
-    padding: 0 calc(50vw - 50%);
-    overflow: hidden;
+    // margin: 0 calc(50% - 50vw - (100vw - 100%));
+    // padding: 0 calc(50vw - 50%);
+    // overflow: hidden;
   }
 
   &__arrow {

--- a/src/styles/components/_carousel.scss
+++ b/src/styles/components/_carousel.scss
@@ -36,13 +36,6 @@ $mc-carousel-centered-padding: 100px !default;
     }
   }
 
-
-  &__container {
-    // margin: 0 calc(50% - 50vw - (100vw - 100%));
-    // padding: 0 calc(50vw - 50%);
-    // overflow: hidden;
-  }
-
   &__arrow {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
## Overview
Issue with overflowing container widths on the fadeEdges carousel. Removing until solution is found since this carousel isn't used anywhere

## Risks
None

## Changes

## Issue
https://github.com/yankaindustries/mc-components/issues/296