### PR TITLE
Adding 21x9 tile aspect ratio

### DIFF
--- a/src/components/Tile/index.js
+++ b/src/components/Tile/index.js
@@ -8,11 +8,12 @@ export default class Tile extends PureComponent {
       '1x1',
       '4x3',
       '9x16',
-      '16x9',
       '3x4',
-      '519x187',
+      '16x9',
+      '21x9',
 
       // DEPRECATE
+      '519x187',
       '100x65',
       '1000x609',
     ]),

--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -276,6 +276,12 @@ storiesOf('components|Tiles/Tile', module)
                 <Placeholder>4x3</Placeholder>
               </Tile>
             </div>
+
+            <div className='col-sm-12'>
+              <Tile aspectRatio='21x9'>
+                <Placeholder>21x9</Placeholder>
+              </Tile>
+            </div>
           </div>
         </PropExample>
       </DocSection>

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -74,6 +74,10 @@
     @include tile-aspect-ratio(16, 9);
   }
 
+  &--21x9 {
+    @include tile-aspect-ratio(21, 9);
+  }
+
   &--9x16 {
     @include tile-aspect-ratio(9, 16);
   }


### PR DESCRIPTION
## Overview
Will noticed a new style / aspect ratio for a tile he was working on for the new instructor announcement banner experiment.  Confirmed with Sean that a new aspect ratio will be needed moving forward: 21:9.

## Risks
None, doesn't affect existing components, merely adds a new option.

## Changes
![image](https://user-images.githubusercontent.com/505670/48812302-8b63b200-ece6-11e8-8e75-d6e23e2d53d2.png)


## Issue
N/A