### PR TITLE
Updating positioning for tilecaption

### DIFF
--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -153,8 +153,8 @@ storiesOf('components|Tiles', module)
 
                     <TileCaption
                       position={intent
-                        ? 'left below'
-                        : 'left bottom'
+                        ? 'x-left y-below'
+                        : 'x-left y-bottom'
                       }
                     >
                       <Background

--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -153,8 +153,8 @@ storiesOf('components|Tiles', module)
 
                     <TileCaption
                       position={intent
-                        ? 'x-left y-below'
-                        : 'x-left y-bottom'
+                        ? 'left below'
+                        : 'left bottom'
                       }
                     >
                       <Background

--- a/src/components/TileCaption/index.js
+++ b/src/components/TileCaption/index.js
@@ -10,15 +10,20 @@ export default class TileCaption extends PureComponent {
     ]),
     className: PropTypes.string,
     position: PropTypes.oneOf([
-      'left bottom',
-      'center bottom',
-      'left below',
-      'center below',
+      'x-left y-center',
+      'x-left y-bottom',
+      'x-left y-below',
+      'x-center y-center',
+      'x-center y-bottom',
+      'x-center y-below',
+      'x-right y-center',
+      'x-right y-bottom',
+      'x-right y-below',
     ]),
   }
 
   static defaultProps = {
-    position: 'left bottom',
+    position: 'x-left y-bottom',
   }
 
   render () {

--- a/src/components/TileCaption/index.js
+++ b/src/components/TileCaption/index.js
@@ -10,20 +10,20 @@ export default class TileCaption extends PureComponent {
     ]),
     className: PropTypes.string,
     position: PropTypes.oneOf([
-      'x-left y-center',
-      'x-left y-bottom',
-      'x-left y-below',
-      'x-center y-center',
-      'x-center y-bottom',
-      'x-center y-below',
-      'x-right y-center',
-      'x-right y-bottom',
-      'x-right y-below',
+      'left center',
+      'left bottom',
+      'left below',
+      'center center',
+      'center bottom',
+      'center below',
+      'right center',
+      'right bottom',
+      'right below',
     ]),
   }
 
   static defaultProps = {
-    position: 'x-left y-bottom',
+    position: 'left bottom',
   }
 
   render () {
@@ -33,13 +33,13 @@ export default class TileCaption extends PureComponent {
       position,
     } = this.props
 
-    const positionClasses =
-      position.split(' ').map(pos => `mc-tile-caption--${pos}`)
+    const [x, y] = position.split(' ')
 
     const classes = [
       'mc-tile__component',
       'mc-tile-caption',
-      ...positionClasses,
+      `mc-tile-caption--x-${x}`,
+      `mc-tile-caption--y-${y}`,
       className || '',
     ].join(' ')
 

--- a/src/components/TileCaption/index.js
+++ b/src/components/TileCaption/index.js
@@ -14,6 +14,7 @@ export default class TileCaption extends PureComponent {
       'left bottom',
       'left below',
       'center center',
+      'center',
       'center bottom',
       'center below',
       'right center',
@@ -33,7 +34,13 @@ export default class TileCaption extends PureComponent {
       position,
     } = this.props
 
-    const [x, y] = position.split(' ')
+    // eslint-disable-next-line prefer-const
+    let [x, y] = position.split(' ')
+
+    // Support shorthand for 'center' => 'center center'
+    if (x === 'center' && !y) {
+      y = 'center'
+    }
 
     const classes = [
       'mc-tile__component',

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -23,7 +23,36 @@ storiesOf('components|Tiles/TileCaption', module)
           <div className='row'>
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='left bottom'>
+                <TileCaption position='x-left y-center'>
+                  left center
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='x-center y-center'>
+                  center center
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='x-right y-center'>
+                  right center
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+          </div>
+
+          <div className='row'>
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='x-left y-bottom'>
                   left bottom
                 </TileCaption>
                 <Placeholder />
@@ -32,7 +61,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='center bottom'>
+                <TileCaption position='x-center y-bottom'>
                   center bottom
                 </TileCaption>
                 <Placeholder />
@@ -41,8 +70,37 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='left below'>
+                <TileCaption position='x-right y-bottom'>
                   left below
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+          </div>
+
+          <div className='row'>
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='x-left y-below'>
+                  left below
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='x-center y-below'>
+                  center below
+                </TileCaption>
+                <Placeholder />
+              </Tile>
+            </div>
+
+            <div className='col-sm-4'>
+              <Tile>
+                <TileCaption position='x-right y-below'>
+                  right below
                 </TileCaption>
                 <Placeholder />
               </Tile>

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -32,7 +32,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='center center'>
+                <TileCaption position='center'>
                   center center
                 </TileCaption>
                 <Placeholder />

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -71,7 +71,7 @@ storiesOf('components|Tiles/TileCaption', module)
             <div className='col-sm-4'>
               <Tile>
                 <TileCaption position='x-right y-bottom'>
-                  left below
+                  right bottom
                 </TileCaption>
                 <Placeholder />
               </Tile>

--- a/src/components/TileCaption/index.stories.js
+++ b/src/components/TileCaption/index.stories.js
@@ -23,7 +23,7 @@ storiesOf('components|Tiles/TileCaption', module)
           <div className='row'>
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-left y-center'>
+                <TileCaption position='left center'>
                   left center
                 </TileCaption>
                 <Placeholder />
@@ -32,7 +32,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-center y-center'>
+                <TileCaption position='center center'>
                   center center
                 </TileCaption>
                 <Placeholder />
@@ -41,7 +41,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-right y-center'>
+                <TileCaption position='right center'>
                   right center
                 </TileCaption>
                 <Placeholder />
@@ -52,7 +52,7 @@ storiesOf('components|Tiles/TileCaption', module)
           <div className='row'>
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-left y-bottom'>
+                <TileCaption position='left bottom'>
                   left bottom
                 </TileCaption>
                 <Placeholder />
@@ -61,7 +61,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-center y-bottom'>
+                <TileCaption position='center bottom'>
                   center bottom
                 </TileCaption>
                 <Placeholder />
@@ -70,7 +70,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-right y-bottom'>
+                <TileCaption position='right bottom'>
                   right bottom
                 </TileCaption>
                 <Placeholder />
@@ -81,7 +81,7 @@ storiesOf('components|Tiles/TileCaption', module)
           <div className='row'>
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-left y-below'>
+                <TileCaption position='left below'>
                   left below
                 </TileCaption>
                 <Placeholder />
@@ -90,7 +90,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-center y-below'>
+                <TileCaption position='center below'>
                   center below
                 </TileCaption>
                 <Placeholder />
@@ -99,7 +99,7 @@ storiesOf('components|Tiles/TileCaption', module)
 
             <div className='col-sm-4'>
               <Tile>
-                <TileCaption position='x-right y-below'>
+                <TileCaption position='right below'>
                   right below
                 </TileCaption>
                 <Placeholder />

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -197,6 +197,8 @@
 }
 
 .mc-tile-caption {
+  display: flex;
+
   &__content {
     position: absolute;
     padding: 16px;
@@ -207,29 +209,67 @@
   }
 
   // Modifiers
-  &--bottom {
+  &--x-left {
     .mc-tile-caption__content {
-      left: 0;
-      top: 100%;
-      transform: translateY(-100%);
+      text-align: left;
     }
   }
 
-  &--below {
-    .mc-tile-caption__content {
-      left: 0;
-      top: 100%;
-      transform: translateY(0);
-      background: rgba($mc-color-dark, 1);
-      transition: transform 0.2s ease, background 0.2s ease;
-    }
-  }
-
-  &--center {
+  &--x-center {
     .mc-tile-caption__content {
       text-align: center;
     }
   }
+
+  &--x-right {
+    .mc-tile-caption__content {
+      text-align: right;
+    }
+  }
+
+  &--y-center {
+    .mc-tile-caption__content {
+      align-self: center;
+    }
+  }
+
+  &--y-bottom {
+    .mc-tile-caption__content {
+      align-self: flex-end;
+    }
+  }
+
+  &--y-below {
+    .mc-tile-caption__content {
+      align-self: flex-end;
+      transform: translateY(100%);
+      background: rgba($mc-color-dark, 1);
+    }
+  }
+
+  // &--bottom {
+  //   .mc-tile-caption__content {
+  //     left: 0;
+  //     top: 100%;
+  //     transform: translateY(-100%);
+  //   }
+  // }
+
+  // &--below {
+  //   .mc-tile-caption__content {
+  //     left: 0;
+  //     top: 100%;
+  //     transform: translateY(0);
+  //     background: rgba($mc-color-dark, 1);
+  //     transition: transform 0.2s ease, background 0.2s ease;
+  //   }
+  // }
+
+  // &--center {
+  //   .mc-tile-caption__content {
+  //     text-align: center;
+  //   }
+  // }
 }
 
 .mc-tile-check {

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -246,30 +246,6 @@
       background: rgba($mc-color-dark, 1);
     }
   }
-
-  // &--bottom {
-  //   .mc-tile-caption__content {
-  //     left: 0;
-  //     top: 100%;
-  //     transform: translateY(-100%);
-  //   }
-  // }
-
-  // &--below {
-  //   .mc-tile-caption__content {
-  //     left: 0;
-  //     top: 100%;
-  //     transform: translateY(0);
-  //     background: rgba($mc-color-dark, 1);
-  //     transition: transform 0.2s ease, background 0.2s ease;
-  //   }
-  // }
-
-  // &--center {
-  //   .mc-tile-caption__content {
-  //     text-align: center;
-  //   }
-  // }
 }
 
 .mc-tile-check {


### PR DESCRIPTION
## Overview
We need more control over tile caption positioning.  This adds x and y axis control for how the caption aligns.

## Risks
TileCaption previously did not have x and y values, so any place that TileCaption is currently used needs to be updated.  It looks like it's only used at the following location in the main repo right now:

`app/javascript/packs/client/features/promotions/BogoPage/BogoPage.js`

This will be a **breaking change** for anyone that is currently using `TileCaption` or the styles associated with it in their project.  This should be communicated to everyone.

## Changes
#### Old styles
![image](https://user-images.githubusercontent.com/505670/48815574-c15b6300-ecf3-11e8-9dff-d9aca40ddfb2.png)

#### New Styles:
![image](https://user-images.githubusercontent.com/505670/48815785-86a5fa80-ecf4-11e8-8075-89815c2f2a3c.png)

## Issue
N/A