### PR TITLE
VideoPlayer: hide before/pause/endscreens on play & seek for video

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,24 @@ const Container = () =>
 
 All changes are hot-reloaded and you'll be able to see components being modified live as you work.
 
-If you want to develop in `mc-components` and see your work compiled live in your own project (like the masterclass repo), then you can use the following command to hot-reload changes to styles and components:
+If you want to develop in `mc-components` and see your work compiled live in your own project (like the masterclass repo), you can run the following commands:
+
+In `mc-components`: (this creates a symlink to use in your project's repo, and also will let you hot-reload changes to styles and components in mc-components)
 
 ```
+yarn install
+yarn link
 yarn dev
 ```
+
+In your own project (eg MasterClass) directory:
+
+```
+yarn link "mc-components"
+yarn webpack-dev
+```
+
+(Run `yarn unlink` in `mc-components` and `yarn unlink "mc-components"` in your project's repo when you are done developing and want to unlink.)
 
 ## Submit your code
   - Create a PR with your changes

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ yarn dev
 In your own project (eg MasterClass) directory:
 
 ```
-yarn link "mc-components"
+yarn link mc-components
 yarn webpack-dev
 ```
 
-(Run `yarn unlink` in `mc-components` and `yarn unlink "mc-components"` in your project's repo when you are done developing and want to unlink.)
+(Run `yarn unlink "mc-components"` in your project's repo when you are done developing and want to unlink, and then run `yarn install` to reinstall the version of mc-components you were using previously)
 
 ## Submit your code
   - Create a PR with your changes

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -89,6 +89,19 @@ export default class VideoPlayer extends PureComponent {
     }
   }
 
+  hideOpenScreens = () => {
+    const { beforescreenOpen, pausescreenOpen, endscreenOpen } = this.state
+    if (beforescreenOpen) {
+      this.setState({ beforescreenOpen: false })
+    }
+    if (pausescreenOpen) {
+      this.setState({ pausescreenOpen: false })
+    }
+    if (endscreenOpen) {
+      this.setState({ endscreenOpen: false })
+    }
+  }
+
   handlePlayerReady = () => {
     const {
       onSeek,
@@ -100,13 +113,7 @@ export default class VideoPlayer extends PureComponent {
     } = this.props
 
     this.video.on('play', () => {
-      const { beforescreenOpen, pausescreenOpen } = this.state
-      if (beforescreenOpen) {
-        this.setState({ beforescreenOpen: false })
-      }
-      if (pausescreenOpen) {
-        this.setState({ pausescreenOpen: false })
-      }
+      this.hideOpenScreens()
       if (onPlay) {
         onPlay(this.video)
       }
@@ -123,9 +130,12 @@ export default class VideoPlayer extends PureComponent {
 
     this.video.on('ended', this.handleVideoEnd)
 
-    if (onSeek) {
-      this.video.on('seeking', onSeek)
-    }
+    this.video.on('seeking', () => {
+      this.hideOpenScreens()
+      if (onSeek) {
+        onSeek(this.video)
+      }
+    })
 
     this.video.on('loadedmetadata', () => {
       this.checkBuffers()


### PR DESCRIPTION
## Overview
- hide beforescreens, pausescreens, and endscreens when you play or seek on a video. This allows you to rewatch a video from an endscreen by just clicking play, and lets you seek on a video without the dark overlay from the pausescreen being activated.
- updated the readme with more detailed instructions on how to link in your repo (for other masterclass frontend noobs like me who got a little lost trying to do it for the first time)

## Risks
- Low? It affects the video player, but only if there are pausescreens, endscreens, and beforescreens (and only if they are open). I manually tested this on Playlists and on the Chapters#Watch page videos.

## Changes
- Hides the pausescreen when seeking on a video:
![image](https://user-images.githubusercontent.com/10948775/48863430-307d9980-ed7e-11e8-9948-b3b158bc6225.png)

- Hides the endscreen (and pausescreens & beforescreens) when playing a video, which allows you to rewatch a video from this screen. Previously, endscreen would stay open indefinitely once the video ended, even if you replay:
![image](https://user-images.githubusercontent.com/10948775/48863496-63279200-ed7e-11e8-90de-970ad009152d.png)


## Issue
Fixes item 2 on this ticket (rest are not issues with the video player, but instead with the pausescreen & endscreen components being shared): https://masterclass-dev.atlassian.net/browse/RET-344
