### PR TITLE
Changing REM base to 10px

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -62,7 +62,7 @@ $mc-zindex-popover:           1060 !default;
 $mc-zindex-tooltip:           1070 !default;
 
 // Step measurements
-$mc-step-base: 16 !default;
+$mc-step-base: 10 !default;
 $mc-step-scale: 4 !default;
 $mc-step-multipliers: 7 !default;
 $mc-step-min-resize: 4 !default;


### PR DESCRIPTION
## Overview
Somehow REM base font size got set back to 16 (possibly bad merge/rebase)?!  Changing back to 10.

## Risks
None