### PR TITLE
Updating carousel for overflowing hover effects

### DIFF
--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -148,6 +148,7 @@ export default class Carousel extends PureComponent {
           slidesToScroll={scrollCount}
           slidesToShow={showCount}
           infinite={loop}
+          draggable={false}
           {...arrows}
           {...restProps}
         >

--- a/src/styles/components/_carousel.scss
+++ b/src/styles/components/_carousel.scss
@@ -4,6 +4,24 @@ $scrollbar-max-width: 17px !default;
 .mc-carousel {
   position: relative;
 
+  // We need to override slick sliders default scss
+  // so that we can have cool hover effects and not cut off
+  // tiles that overflow the slick container
+  .slick-list {
+    overflow: visible;
+  }
+
+  .slick-slide {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 250ms ease;
+  }
+
+  .slick-active {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   &__container {
     margin: 0 calc(50% - 50vw + #{$scrollbar-max-width / 2});
     padding: 0 calc(50vw - 50% - #{$scrollbar-max-width / 2});
@@ -106,8 +124,9 @@ $scrollbar-max-width: 17px !default;
   }
 
   &--overflow {
-    .slick-list {
-      overflow: visible;
+    .slick-slide {
+      opacity: 1;
+      pointer-events: auto;
     }
   }
 


### PR DESCRIPTION
## Overview
Content in a carousel was being cut off when overflow hidden was set.  Update carousel component to support overflowing content more gracefully.

![image](https://user-images.githubusercontent.com/505670/50113845-f3c78580-01f7-11e9-8571-0971d8a6ed69.png)

## Risks
Low - existing implementation should be unaffected by this change.

## Changes
- Removes "draggable" tiles
- Adds subtle opacity animation as slides come in / exit
- Adds support for hover states of tiles growing outside of bounding area of carousel

## Issue
https://github.com/yankaindustries/mc-components/issues/320