### PR TITLE
Fix tile overlay background issue

### DIFF
--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -157,10 +157,6 @@
 }
 
 .mc-tile-overlay {
-  // 1.01 guarantees extra coverage in case of
-  // pixel rounding down to be too small
-  transform: scale(1.01);
-
   &--gradient-bottom {
     background:
       linear-gradient(
@@ -168,7 +164,7 @@
         rgba($mc-color-dark, 0.9) 0,
         rgba($mc-color-dark, 0.6) 25%,
         rgba($mc-color-dark, 0) 45%
-      );
+      ) center no-repeat;
   }
 
   &--offset-spotlight {


### PR DESCRIPTION
## Overview
There was an issue with the tileOverlays being too large or too small for the tiles because of overflows and a 1px "rounding error" from subpixel calculations in CSS.  While troubleshooting, I found that centering a background linear gradient will force calculations to match the parent containers better, and resolves (for the most part) the issue we're seeing.

There is still a rendering issue where the tile overlay is calculated incorrectly and "off by one" pixel on hover, but it won't be noticeable on 99% of the tiles.

## Risks
Low

## Changes
Fixes 1px miscalculation on tile overlays

## Issue
https://github.com/yankaindustries/mc-components/issues/297