### PR TITLE
Add helper class for breaking content out of container

### DIFF
--- a/src/foundation/grid/index.stories.js
+++ b/src/foundation/grid/index.stories.js
@@ -15,6 +15,7 @@ storiesOf('foundation|Grid', module)
 
       <div className='example__section'>
         <p className='mc-text--muted mc-text--monospace'>.row</p>
+
         <CodeExample>
           <div className='row'>
             <div className='col-6'>
@@ -72,6 +73,26 @@ storiesOf('foundation|Grid', module)
             </div>
           </div>
         </CodeExample>
+      </div>
+
+      <div className='uncontainer'>
+        <div className='rounded-box'>
+          <h2 className='mc-text-h2'>
+            Pro tip!
+          </h2>
+          <p className=''>
+            You can use the <span className='mc-text--monospace'>.uncontainer</span>
+            class name to break any div out from the inside of a container div.
+          </p>
+
+          <p>
+            The <span className='mc-text--monospace'>.uncontainer</span>
+            class pulls your content out of the wrapping
+            <span className='mc-text--monospace'>.container</span> class
+            so your content lines up just as if it were inside a regular
+            container!
+          </p>
+        </div>
       </div>
 
       <div className='example__section'>

--- a/src/styles/base/_body.scss
+++ b/src/styles/base/_body.scss
@@ -1,4 +1,5 @@
 body {
   background: $mc-color-background;
   color: $mc-color-text;
+  overflow-x: hidden;
 }

--- a/src/styles/helpers/_grid.scss
+++ b/src/styles/helpers/_grid.scss
@@ -1,0 +1,5 @@
+// Break any div out from a wrapping
+// .container class!
+.uncontainer {
+  margin: 0 calc(50% - 50vw);
+}

--- a/src/styles/helpers/_helpers.scss
+++ b/src/styles/helpers/_helpers.scss
@@ -1,1 +1,2 @@
 @import "images";
+@import "grid";


### PR DESCRIPTION
## Overview
Add helper class for breaking content out of container

## Risks
Medium - adds `overflow-x: hidden;` to body, so this has the potential to cause issues with overflowing content.

## Changes
![image](https://user-images.githubusercontent.com/505670/50254255-48a6ff80-03a2-11e9-84df-448111e88882.png)

## Issue
https://github.com/yankaindustries/mc-components/issues/273