### PR TITLE
Add highlightOnActive and highlightOnHover props to carousel component

### DIFF
--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -71,12 +71,14 @@ export default class Carousel extends PureComponent {
     children: PropTypes.node,
     className: PropTypes.string,
     controls: PropTypes.bool,
-    overflow: PropTypes.bool,
     focusOnSelect: PropTypes.bool,
-    sliderRef: PropTypes.func,
+    highlightOnActive: PropTypes.bool,
+    highlightOnHover: PropTypes.bool,
     loop: PropTypes.bool,
+    overflow: PropTypes.bool,
     scrollCount: PropTypes.number,
     showCount: PropTypes.number,
+    sliderRef: PropTypes.func,
     transition: PropTypes.string,
     variableWidth: PropTypes.bool,
   }
@@ -85,9 +87,11 @@ export default class Carousel extends PureComponent {
     autoPlay: false,
     centered: false,
     controls: false,
-    overflow: false,
     focusOnSelect: false,
+    highlightOnActive: false,
+    highlightOnHover: false,
     loop: false,
+    overflow: false,
     scrollCount: 1,
     showCount: 3,
     transition: TRANSITION_SLIDE,
@@ -97,15 +101,17 @@ export default class Carousel extends PureComponent {
   render () {
     const {
       autoPlay,
+      centered,
       children,
       className,
-      centered,
       controls,
-      overflow,
+      highlightOnActive,
+      highlightOnHover,
       loop,
-      sliderRef,
+      overflow,
       scrollCount,
       showCount,
+      sliderRef,
       transition,
       ...restProps
     } = this.props
@@ -116,6 +122,8 @@ export default class Carousel extends PureComponent {
       `mc-carousel--${transition}`,
       centered ? 'mc-carousel--centered' : '',
       overflow ? 'mc-carousel--overflow' : '',
+      highlightOnActive ? 'mc-carousel--highlight-active' : '',
+      highlightOnHover ? 'mc-carousel--highlight-hover' : '',
     ].join(' ')
 
     const arrows = controls

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -234,6 +234,50 @@ storiesOf('components|Carousel', module)
             </Carousel>
           </div>
         </PropExample>
+
+        <PropExample
+          name='highlightOnActive'
+          type='Boolean'
+        >
+          <div className='row'>
+            <Carousel highlightOnActive>
+              {items.map((item, key) => (
+                <div key={key} className='col-auto'>
+                  <Tile key={item.id}>
+                    <TileImage imageUrl={item.thumbnail} />
+                    <TileOverlay />
+                    <TileCaption
+                      title={item.instructor}
+                      subtitle={`Teaches ${item.teaches}`}
+                    />
+                  </Tile>
+                </div>
+              ))}
+            </Carousel>
+          </div>
+        </PropExample>
+
+        <PropExample
+          name='highlightOnHover'
+          type='Boolean'
+        >
+          <div className='row'>
+            <Carousel highlightOnHover>
+              {items.map((item, key) => (
+                <div key={key} className='col-auto'>
+                  <Tile key={item.id}>
+                    <TileImage imageUrl={item.thumbnail} />
+                    <TileOverlay />
+                    <TileCaption
+                      title={item.instructor}
+                      subtitle={`Teaches ${item.teaches}`}
+                    />
+                  </Tile>
+                </div>
+              ))}
+            </Carousel>
+          </div>
+        </PropExample>
       </DocSection>
     </div>
   )))

--- a/src/styles/components/_components.scss
+++ b/src/styles/components/_components.scss
@@ -2,7 +2,7 @@
 @import "badge";
 @import "buttons/buttons";
 @import "footer";
-@import "carousel";
+@import "carousel/carousel";
 @import "forms/forms";
 @import "icons";
 @import "mobile-nav-button";

--- a/src/styles/components/carousel/_base.scss
+++ b/src/styles/components/carousel/_base.scss
@@ -130,13 +130,6 @@ $scrollbar-max-width: 17px !default;
     }
   }
 
-  &--overflow {
-    .slick-slide {
-      opacity: 1;
-      pointer-events: auto;
-    }
-  }
-
   // DEPRECATED
   &__slide {
     width: 320px;

--- a/src/styles/components/carousel/_carousel.scss
+++ b/src/styles/components/carousel/_carousel.scss
@@ -1,0 +1,2 @@
+@import "base";
+@import "modifiers";

--- a/src/styles/components/carousel/_modifiers.scss
+++ b/src/styles/components/carousel/_modifiers.scss
@@ -1,0 +1,34 @@
+.mc-carousel {
+  &--overflow {
+    .slick-slide {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+
+  &--highlight-active {
+    .slick-list {
+      .slick-slide {
+        opacity: 0.5;
+        transition: opacity 250ms ease;
+
+        &.slick-current {
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  &--highlight-hover {
+    .slick-list:hover {
+      .slick-slide {
+        opacity: 0.5;
+        transition: opacity 250ms ease;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Adds two new properties to the carousel component:
- `highlightOnActive` when set will dim all non focused slides
- `highlightOnHover` when set will dim all slides except the slide you hover over

## Risks
None - new properties

## Changes
![kapture 2019-01-02 at 15 26 08](https://user-images.githubusercontent.com/505670/50617563-c559d380-0ea2-11e9-8769-3b8f2bb69778.gif)

## Issue
https://github.com/yankaindustries/mc-components/issues/314