### PR TITLE
Adding better handling for form input states like hover and error

### DIFF
--- a/src/styles/components/forms/input/_default.scss
+++ b/src/styles/components/forms/input/_default.scss
@@ -4,6 +4,7 @@
   border: 1px solid $mc-color-gray-300;
   background: $mc-color-gray-200;
   border-radius: 4px;
+  color: $mc-color-gray-500;
   width: 100%;
 
   cursor: text;
@@ -41,6 +42,7 @@
 
   &:hover {
     border-color: $mc-color-gray-400;
+    color: $mc-color-gray-600;
   }
 
   &--focus {

--- a/src/styles/components/forms/input/_modifiers.scss
+++ b/src/styles/components/forms/input/_modifiers.scss
@@ -22,10 +22,6 @@
     border-color: $mc-color-primary-hover;
   }
 
-  .mc-form-input__label {
-    color: $mc-color-primary;
-  }
-
   // Override default focus state
   // with more specificty for errors
   &.mc-form-input--focus,
@@ -75,6 +71,11 @@
     // (it just mirrors what's above on the regular
     // default error class)
     &--error {
+      border-color: $mc-color-primary;
+
+      &:hover {
+        border-color: $mc-color-primary-hover;
+      }
       &.mc-form-input--focus,
       &.mc-form-input--modified {
         border-color: $mc-color-primary-active;


### PR DESCRIPTION
## Overview
This is a fix for input labels error states and hover styles.

## Risks
Low - some changes to CSS, but intended to fix an existing bug, so hopefully an improvement :D

## Changes
Based on [figma comps](https://www.figma.com/file/X4sR3879DmwTYCRG72WKquAP/Components---In-Progress?node-id=4079%3A1901) per design.
Previous error state:
![image](https://user-images.githubusercontent.com/505670/50618232-53838900-0ea6-11e9-8c2e-f1570e8f0084.png)

New:
![image](https://user-images.githubusercontent.com/505670/50618247-6a29e000-0ea6-11e9-803e-d19d2da391ae.png)


## Issue
https://github.com/yankaindustries/mc-components/issues/281