### PR TITLE
Removing linkMuted from <Button />`

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -13,24 +13,20 @@ const Button = ({
   tertiary,
   fullWidth,
   link,
-  linkMuted,
   loading,
   Icon,
   ...props
 }) => {
-  const classNames = cn(
-    'c-button',
-    { [className]: Boolean(className) },
-    {
-      'c-button--secondary': secondary,
-      'c-button--tertiary': tertiary,
-      'c-button--with-icon': Boolean(Icon),
-      'c-button--full-width': fullWidth,
-      'c-button--link': link,
-      'c-button--link-muted': linkMuted,
-      'c-button--loading': loading,
-    },
-  )
+  const classNames = cn({
+    [className]: Boolean(className),
+    'c-button': true,
+    'c-button--secondary': secondary,
+    'c-button--tertiary': tertiary,
+    'c-button--with-icon': Boolean(Icon),
+    'c-button--full-width': fullWidth,
+    'c-button--link': link,
+    'c-button--loading': loading,
+  })
 
   return (
     <button
@@ -59,7 +55,6 @@ Button.propTypes = {
   tertiary: bool,
   fullWidth: bool,
   link: bool,
-  linkMuted: bool,
   loading: bool,
   Icon: node,
 }
@@ -71,7 +66,6 @@ Button.defaultProps = {
   tertiary: false,
   fullWidth: false,
   link: false,
-  linkMuted: false,
   loading: false,
 }
 

--- a/src/styles/components/buttons/_button--inverted.scss
+++ b/src/styles/components/buttons/_button--inverted.scss
@@ -39,17 +39,5 @@
         }
       }
     }
-
-    &--link-muted {
-      color: rgba($mc-color-dark, 0.5);
-
-      span:after {
-        background: rgba($mc-color-dark, 0.25);
-      }
-
-      &:hover {
-        color: rgba($mc-color-dark, 0.5);
-      }
-    }
   }
 }

--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -101,8 +101,7 @@
     }
   }
 
-  &--link,
-  &--link-muted {
+  &--link {
     background: none;
     color: $mc-color-light;
 
@@ -141,19 +140,6 @@
       span:after {
         opacity: 0;
       }
-    }
-  }
-
-  // Subtler!
-  &--link-muted {
-    color: rgba($mc-color-light, 0.5);
-
-    span:after {
-      background: rgba($mc-color-light, 0.25);
-    }
-
-    &:hover {
-      color: rgba($mc-color-light, 0.5);
     }
   }
 }


### PR DESCRIPTION
## Overview
`<Button linkMuted />` looks like a disabled `<Button link />` so we are killing it.

## Risks
None, the removal of `linkMuted` instances has already been done in `masterclass`

## Issue
#283
