### PR TITLE
Remove abstraction for button colors so colors are more obvious

### DIFF
--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -53,25 +53,25 @@
   }
 
   &--secondary {
-    background: $mc-color-secondary;
+    background: $mc-color-gray-200;
 
     &:hover {
-      background: $mc-color-secondary-hover;
+      background: $mc-color-gray-300;
     }
 
     &:active {
-      background: $mc-color-secondary-active;
+      background: $mc-color-gray-200;
     }
 
     // disabled
     &.disabled,
     &:disabled {
       &:hover {
-        background: $mc-color-secondary;
+        background: $mc-color-gray-200;
       }
 
       &:active {
-        background: $mc-color-secondary;
+        background: $mc-color-gray-200;
       }
     }
   }
@@ -81,11 +81,11 @@
     border: 1px solid $mc-color-gray-300;
 
     &:hover {
-      background: $mc-color-tertiary-hover;
+      background: $mc-color-gray-300;
     }
 
     &:active {
-      background: $mc-color-tertiary-active;
+      background: $mc-color-gray-200;
     }
 
     // disabled


### PR DESCRIPTION
## Overview
The original ticket was to create new variables for buttons so they were specifically set with intent.  I believe an extra layer of abstraction here isn't warranted - setting the gray colors specifically communicates to future devs updating button codes exactly what these colors are / do without having to look them up in variables.

## Risks
None - old variable names are still there for now until the code freeze is over and we can safely remove the references to them in the mc repo.

## Changes
No visible changes

## Issue
https://github.com/yankaindustries/mc-components/issues/302