### PR TITLE
quiet those lint warnings, we dont need em

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start": "NODE_ENV=development start-storybook -p 9001 -c .storybook",
     "deploy-storybook": "storybook-to-ghpages",
     "precommit": "lint-staged",
-    "lint:js": "eslint ./src --color",
+    "lint:js": "eslint ./src --color --quiet",
     "lint:style": "stylelint ./src/styles/**/*.scss",
     "lint": "yarn lint:js && yarn lint:style",
     "preversion": "yarn lint",


### PR DESCRIPTION
## Overview
We don't do anything with lint warnings, and they are just piling up.  If we want to address the warnings, we should make the rules actual errors instead.  This PR quiets the warnings.  We can address them later if we want to, but I don't see a need.

## Risks
None

## Issue
#145