### PR TITLE
Update copyright year on footer

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -15,6 +15,7 @@ export default class Footer extends PureComponent {
 
   render () {
     const { isMinimal } = this.props
+    const currentYear = new Date().getFullYear()
 
     return (
       <Fragment>
@@ -76,7 +77,7 @@ export default class Footer extends PureComponent {
                   </li>
 
                   <p className='mc-site-footer__copyright mc-text-small mc-text--capitalize'>
-                    Copyright &copy; 2018 MasterClass
+                    Copyright &copy; {currentYear} MasterClass
                   </p>
                 </ul>
 


### PR DESCRIPTION
## Overview
Updates the copyright year on the footer. Uses Date() instead of hardcoded value so it can be automatically updated in the future. 

## Risks
None

## Changes
![image](https://user-images.githubusercontent.com/2998072/50904022-00f22180-13fe-11e9-9274-2d91ba6f3694.png)

## Related Ticket
https://masterclass-dev.atlassian.net/browse/VIR-185
