### PR TITLE
Spacing helpers

### DIFF
--- a/src/components/Background/index.stories.js
+++ b/src/components/Background/index.stories.js
@@ -84,11 +84,11 @@ storiesOf('components|Background', module)
                 <br />
                 <br />
                 <div className='container mc-text--center'>
-                  <h2 className='mc-text-h4 mc-text--airy mcb-space-4'>
+                  <h2 className='mc-text-h4 mc-text--airy mc-mb-4'>
                     Learn From The Best
                   </h2>
 
-                  <p className='mc-text--muted mcb-space-5'>
+                  <p className='mc-text--muted mc-mb-5'>
                     Visit our blog for a deeper dive
                     into all things MasterClass.
                   </p>

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -317,10 +317,10 @@ storiesOf('components|Carousel', module)
                                 <h2 className='mc-text-h1 mc-text--uppercase mc-text--center mc-text-md--left mc-text--nowrap'>
                                   {item.instructor}
                                 </h2>
-                                <h3 className='mc-text-h3 mc-text--muted mc-text--uppercase mc-text--normal mc-text--airy mc-text--center mc-text-md--left mc-text--nowrap mcb-space-4'>
+                                <h3 className='mc-text-h3 mc-text--muted mc-text--uppercase mc-text--normal mc-text--airy mc-text--center mc-text-md--left mc-text--nowrap mc-mb-4'>
                                   Teaches {item.teaches}
                                 </h3>
-                                <p className='mc-text-intro mc-text--center mc-text-md--left mcb-space-8'>
+                                <p className='mc-text-intro mc-text--center mc-text-md--left mc-mb-8'>
                                   Online classes taught by the world&apos;s
                                   greatest minds.<br /> Learn from
                                   {item.instructor} and all 35+ other

--- a/src/playground/home/index.stories.js
+++ b/src/playground/home/index.stories.js
@@ -101,10 +101,10 @@ storiesOf('playground|Pages', module)
                                     <h1 className='mc-text-h1 mc-text--uppercase mc-text--center mc-text-md--left'>
                                       {item.instructor}
                                     </h1>
-                                    <h4 className='mc-text-h4 mc-text--muted mc-text--normal mc-text--center mc-text-md--left mc-text--nowrap mcb-space-4'>
+                                    <h4 className='mc-text-h4 mc-text--muted mc-text--normal mc-text--center mc-text-md--left mc-text--nowrap mc-mb-4'>
                                       Teaches {item.class}
                                     </h4>
-                                    <p className='mc-text-intro mc-text--center mc-text-md--left mc-text--nowrap mcb-space-4'>
+                                    <p className='mc-text-intro mc-text--center mc-text-md--left mc-text--nowrap mc-mb-4'>
                                       Online classes taught by the world&apos;s
                                       greatest minds.<br /> Learn from
                                       {item.instructor} and all 35+ other
@@ -603,7 +603,7 @@ storiesOf('playground|Pages', module)
 
                       <div className='col-12'>
                         <img
-                          className='mc-card__image mcb-space-4'
+                          className='mc-card__image mc-mb-4'
                           src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/instructor-announcements/steve-martin-7ff79ae2d7ec7677b76aa0dfe1c51b47c8b54d6065d330be11c49388e68624ad.jpg'
                         />
                         <p>

--- a/src/playground/typography/index.stories.js
+++ b/src/playground/typography/index.stories.js
@@ -11,14 +11,14 @@ storiesOf('playground|Typography', module)
   .add('Examples', () =>
     <div className='container'>
       <div className='example__section'>
-        <div className='mcb-space-9'>
+        <div className='mc-mb-9'>
           <div className='row'>
             <div className='col-sm-6 offset-sm-1'>
               <h2 className='mc-text-h5 mc-text--muted mc-text--normal mc-text--airy mc-text--uppercase'>
                 Lorem Ipsum
               </h2>
 
-              <h4 className='mc-text-h4 mcb-space-2'>
+              <h4 className='mc-text-h4 mc-mb-2'>
                 Clean &amp; Simple Title Text
               </h4>
             </div>
@@ -27,44 +27,44 @@ storiesOf('playground|Typography', module)
 
         <div className='row'>
           <div className='col-sm-6 offset-sm-1'>
-            <div className='mcb-space-9'>
-              <h3 className='mc-text-h3 mc-text--uppercase mcb-space-2'>
+            <div className='mc-mb-9'>
+              <h3 className='mc-text-h3 mc-text--uppercase mc-mb-2'>
                 Group Workshop: From Here To Alli By Corey Wright
               </h3>
-              <p className='mc-text--muted mcb-space-2'>
+              <p className='mc-text--muted mc-mb-2'>
                 Every great story is born from intentions and obstacles.
                 Learn how to build the &quot;drive shaft&quot; that will
                 set your script in motion.
               </p>
-              <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-text--normal mcb-space-3'>
+              <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-text--normal mc-mb-3'>
                 Lesson 16 // 5min 40s
               </h6>
             </div>
 
-            <div className='mcb-space-9'>
-              <h3 className='mc-text-h5 mcb-space-2'>
+            <div className='mc-mb-9'>
+              <h3 className='mc-text-h5 mc-mb-2'>
                 Group Workshop: From Here To Alli By Corey Wright
               </h3>
-              <p className='mc-text--muted mcb-space-2'>
+              <p className='mc-text--muted mc-mb-2'>
                 Every great story is born from intentions and obstacles.
                 Learn how to build the &quot;drive shaft&quot; that will
                 set your script in motion.
               </p>
-              <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-text--normal mcb-space-3'>
+              <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-text--normal mc-mb-3'>
                 Lesson 16 // 5min 40s
               </h6>
             </div>
 
-            <div className='mcb-space-9'>
-              <h3 className='mc-text-h5 mcb-space-2'>
+            <div className='mc-mb-9'>
+              <h3 className='mc-text-h5 mc-mb-2'>
                 Group Workshop: From Here To Alli By Corey Wright
               </h3>
-              <p className='mc-text--muted mcb-space-2'>
+              <p className='mc-text--muted mc-mb-2'>
                 Every great story is born from intentions and obstacles.
                 Learn how to build the &quot;drive shaft&quot; that will
                 set your script in motion.
               </p>
-              <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-text--normal mcb-space-3'>
+              <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-text--normal mc-mb-3'>
                 Lesson 16 // 5min 40s
               </h6>
             </div>
@@ -79,11 +79,11 @@ storiesOf('playground|Typography', module)
               </div>
 
               <div className='col-10'>
-                <h6 className='mc-text-h7 mc-text--muted mc-text--uppercase mcb-space-2'>
+                <h6 className='mc-text-h7 mc-text--muted mc-text--uppercase mc-mb-2'>
                   Up Next
                 </h6>
 
-                <h6 className='mc-text-h6 mcb-space-2'>
+                <h6 className='mc-text-h6 mc-mb-2'>
                   Mastering Ingredients: Vegetables &amp; Herbs
                 </h6>
                 <p className='mc-text-x-small mc-text--muted'>
@@ -104,7 +104,7 @@ storiesOf('playground|Typography', module)
               </div>
 
               <div className='col-10'>
-                <h6 className='mc-text-h6 mcb-space-2'>
+                <h6 className='mc-text-h6 mc-mb-2'>
                   Mastering Ingredients: Vegetables &amp; Herbs
                 </h6>
                 <p className='mc-text-x-small mc-text--muted'>
@@ -125,7 +125,7 @@ storiesOf('playground|Typography', module)
               </div>
 
               <div className='col-10'>
-                <h6 className='mc-text-h6 mcb-space-2'>
+                <h6 className='mc-text-h6 mc-mb-2'>
                   Mastering Ingredients: Vegetables &amp; Herbs
                 </h6>
                 <p className='mc-text-x-small mc-text--muted'>
@@ -155,15 +155,15 @@ storiesOf('playground|Typography', module)
                       </Tile>
 
                       <div className='mc-card mc-background mc-background--dark'>
-                        <h6 className='mc-text-h7 mc-text--muted mc-text--uppercase mcb-space-2'>
+                        <h6 className='mc-text-h7 mc-text--muted mc-text--uppercase mc-mb-2'>
                           Building Your Home Studio
                         </h6>
 
-                        <h4 className='mc-text-h4 mcb-space-2'>
+                        <h4 className='mc-text-h4 mc-mb-2'>
                           Margaret Atwood
                         </h4>
 
-                        <p className='mc-text--muted mcb-space-2'>
+                        <p className='mc-text--muted mc-mb-2'>
                           Mixtape tumblr chartreuse snackwave 8-bit
                           selfies, glossier mumblecore fingerstache church-key
                           kombucha. Hot chocolate.

--- a/src/styles/base/_beta.scss
+++ b/src/styles/base/_beta.scss
@@ -1,5 +1,1 @@
-.mcb-space {
-  @for $i from 1 to 12 {
-    &-#{$i} { @include step(margin-bottom, $i); }
-  }
-}
+// For works in progress

--- a/src/styles/helpers/_helpers.scss
+++ b/src/styles/helpers/_helpers.scss
@@ -1,3 +1,4 @@
 @import "images";
 @import "grid";
-@import "spacing";
+@import "spacing-margin";
+@import "spacing-padding";

--- a/src/styles/helpers/_helpers.scss
+++ b/src/styles/helpers/_helpers.scss
@@ -1,2 +1,3 @@
 @import "images";
 @import "grid";
+@import "spacing";

--- a/src/styles/helpers/_spacing-margin.scss
+++ b/src/styles/helpers/_spacing-margin.scss
@@ -16,6 +16,26 @@
   }
 }
 
+// Margins - x axis only
+.mc-mx {
+  @for $i from 1 to 12 {
+    &-#{$i} {
+      @include step(margin-left, $i);
+      @include step(margin-right, $i);
+    }
+  }
+}
+
+// Margins - y axis only
+.mc-my {
+  @for $i from 1 to 12 {
+    &-#{$i} {
+      @include step(margin-top, $i);
+      @include step(margin-bottom, $i);
+    }
+  }
+}
+
 // Margins - top only
 .mc-mt {
   @for $i from 1 to 12 {
@@ -38,46 +58,8 @@
 }
 
 // Margins - left only
-// mc-mb-1 through mc-mb-12
 .mc-ml {
   @for $i from 1 to 12 {
     &-#{$i} { @include step(margin-left, $i); }
-  }
-}
-
-
-// Padding all around
-// mc-p-1 through mc-p-12
-.mc-p {
-  @for $i from 1 to 12 {
-    &-#{$i} { @include step(padding, $i); }
-  }
-}
-
-// Padding - top only
-.mc-pt {
-  @for $i from 1 to 12 {
-    &-#{$i} { @include step(padding-top, $i); }
-  }
-}
-
-// Padding - right only
-.mc-pr {
-  @for $i from 1 to 12 {
-    &-#{$i} { @include step(padding-right, $i); }
-  }
-}
-
-// Padding - bottom only
-.mc-pb {
-  @for $i from 1 to 12 {
-    &-#{$i} { @include step(padding-bottom, $i); }
-  }
-}
-
-// Padding - left only
-.mc-pl {
-  @for $i from 1 to 12 {
-    &-#{$i} { @include step(padding-left, $i); }
   }
 }

--- a/src/styles/helpers/_spacing-padding.scss
+++ b/src/styles/helpers/_spacing-padding.scss
@@ -1,0 +1,65 @@
+// These are modeled after the bootstrap helper classes.
+
+// The premise is mc-m is the base for margins and mc-p is
+// the base for padding.  Here are some examples:
+
+// mc-p-6 = padding "6 scale" all around
+// mc-pt-6 = padding-top "6"
+// mc-pr-6 = padding-right "6"
+// mc-pb-6 = padding-bottom "6"
+// mc-pl-6 = padding-left "6"
+
+// Padding all around
+.mc-p {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding, $i); }
+  }
+}
+
+// Padding on x-axis only
+.mc-px {
+  @for $i from 1 to 12 {
+    &-#{$i} {
+      @include step(padding-left, $i);
+      @include step(padding-right, $i);
+    }
+  }
+}
+
+// Padding on y-axis only
+.mc-py {
+  @for $i from 1 to 12 {
+    &-#{$i} {
+      @include step(padding-top, $i);
+      @include step(padding-bottom, $i);
+    }
+  }
+}
+
+// Padding - top only
+.mc-pt {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-top, $i); }
+  }
+}
+
+// Padding - right only
+.mc-pr {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-right, $i); }
+  }
+}
+
+// Padding - bottom only
+.mc-pb {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-bottom, $i); }
+  }
+}
+
+// Padding - left only
+.mc-pl {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-left, $i); }
+  }
+}

--- a/src/styles/helpers/_spacing.scss
+++ b/src/styles/helpers/_spacing.scss
@@ -1,0 +1,83 @@
+// These are modeled after the bootstrap helper classes.
+
+// The premise is mc-m is the base for margins and mc-p is
+// the base for padding.  Here are some examples:
+
+// mc-m-6 = margin "6 scale" all around
+// mc-mt-6 = margin-top "6"
+// mc-mr-6 = margin-right "6"
+// mc-mb-6 = margin-bottom "6"
+// mc-ml-6 = margin-left "6"
+
+// Margins all around
+.mc-m {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(margin, $i); }
+  }
+}
+
+// Margins - top only
+.mc-mt {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(margin-top, $i); }
+  }
+}
+
+// Margins - right only
+.mc-mr {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(margin-right, $i); }
+  }
+}
+
+// Margins - bottom only
+.mc-mb {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(margin-bottom, $i); }
+  }
+}
+
+// Margins - left only
+// mc-mb-1 through mc-mb-12
+.mc-ml {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(margin-left, $i); }
+  }
+}
+
+
+// Padding all around
+// mc-p-1 through mc-p-12
+.mc-p {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding, $i); }
+  }
+}
+
+// Padding - top only
+.mc-pt {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-top, $i); }
+  }
+}
+
+// Padding - right only
+.mc-pr {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-right, $i); }
+  }
+}
+
+// Padding - bottom only
+.mc-pb {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-bottom, $i); }
+  }
+}
+
+// Padding - left only
+.mc-pl {
+  @for $i from 1 to 12 {
+    &-#{$i} { @include step(padding-left, $i); }
+  }
+}


### PR DESCRIPTION
## Overview
Adds spacing helpers for margins and padding.  It seems like overkill, but after building a few features, we've discovered the majority of CSS needing to be written is for these variables (margins and padding).  These helper classes will allow users to quickly add the spaces they need with some helper classes, while keeping the look consistent with the type scale.  We shouldn't have "custom" values for margins and padding anymore once this is in.

## Risks
None - updated previous "beta" examples where applicable, these are all new classes.

## Changes
Adds ability to use class names like `mc-mb-5` to add a `margin-bottom` value of "5" from the type scale. 

## Issue
N/A