### PR TITLE
Move styles back into default button class

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -35,11 +35,7 @@ const Button = ({
       {...props}
     >
       {Boolean(Icon) && Icon}
-      <span className={`
-        d-inline-flex
-        align-items-center
-        justify-content-center
-      `}>
+      <span>
         {children}
       </span>
       {loading && <Loader className='loader' />}

--- a/src/styles/components/buttons/_button.scss
+++ b/src/styles/components/buttons/_button.scss
@@ -1,6 +1,9 @@
 .c-button,
 .mc-c-btn {
   background-color: $mc-color-primary;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 16px 24px;
   font-size: 12px;
   font-weight: 700;


### PR DESCRIPTION
## Overview
Not sure what I was thinking [here](https://github.com/yankaindustries/mc-components/commit/701631228c024bb26d03a64837d758244ef98612#diff-94b44d795a265db213922807b26dc367) - I had good intentions of moving the styles from the class to the element itself since it was all in react, but I'd forgotten that we use this button class a TON in non-react code, so instead of requiring the end user to add three class names, these css attributes should probably be "built in" to the button class instead.

## Risks
None - reverting back

## Changes
No visual changes, prevents the end users from having to add three class names and correct wrapping `span`s to their buttons.

## Issue
N/A
