### PR TITLE
Fix label alignment for textareas

### DIFF
--- a/src/styles/components/forms/textarea/_default.scss
+++ b/src/styles/components/forms/textarea/_default.scss
@@ -73,7 +73,7 @@ $scrollbarWidth: 7px !default; // Browser scrollbar width
       &__label {
         font-size: 11px;
         transform: translateY(4px);
-        width: calc(100% - (2 * #{$textarea-padding}) - #{$scrollbarWidth});
+        max-width: calc(100% - (2 * #{$textarea-padding}) - #{$scrollbarWidth});
         transition:
           font 320ms ease 0ms,
           transform 320ms ease 0ms;


### PR DESCRIPTION
## Overview
Textarea labels are aligned incorrectly when wrapped inside of a container with `text-align: center;` - this forces the correct left-alignment.

## Risks
None

## Changes
Keeps labels aligned to the left.

## Issue
https://github.com/yankaindustries/mc-components/issues/336