### PR TITLE
Clean memory leaks when video player unmounts

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -95,10 +95,10 @@ export default class VideoPlayer extends PureComponent {
 
   componentWillUnmount () {
     // clean listeners
-    this.video.on('play', () => {})
-    this.video.on('pause', () => {})
-    this.video.on('ended', () => {})
-    this.video.on('seeking', () => {})
+    this.video.off('play')
+    this.video.off('pause')
+    this.video.off('ended')
+    this.video.off('seeking')
     // remove DOM element
     this.video.dispose()
   }


### PR DESCRIPTION
## Overview
Clean listeners and remove the DOM element once the video player unmounts.

## Risks
Medium -

In the playlist watch page we are manually destroying the video player, so we will need to remove that line.