### PR TITLE
modify Modal and VideoPlayer component to work with fullscreen NPS survey

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -22,14 +22,12 @@ export default class Modal extends PureComponent {
     ]).isRequired,
     className: PropTypes.string,
     show: PropTypes.bool,
-    portalNode: PropTypes.instanceOf(Element),
-    usePortal: PropTypes.bool,
+    appendToBody: PropTypes.bool,
     onCloseClick: PropTypes.func,
   }
 
   static defaultProps = {
-    portalNode: document.body,
-    usePortal: true,
+    appendToBody: true,
   }
 
   onKeyDown = (event) => {
@@ -86,17 +84,16 @@ export default class Modal extends PureComponent {
   render () {
     const {
       show,
-      usePortal,
-      portalNode,
+      appendToBody,
     } = this.props
 
     if (!show) {
       return null
     }
 
-    return usePortal ? createPortal(
+    return appendToBody ? createPortal(
       this.renderModal(),
-      portalNode,
+      document.body,
     ) : this.renderModal()
   }
 }

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -22,7 +22,7 @@ export default class Modal extends PureComponent {
     ]).isRequired,
     className: PropTypes.string,
     show: PropTypes.bool,
-    portalNode: PropTypes.node,
+    portalNode: PropTypes.instanceOf(Element),
     usePortal: PropTypes.bool,
     onCloseClick: PropTypes.func,
   }

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -22,8 +22,14 @@ export default class Modal extends PureComponent {
     ]).isRequired,
     className: PropTypes.string,
     show: PropTypes.bool,
-
+    portalNode: PropTypes.node,
+    usePortal: PropTypes.bool,
     onCloseClick: PropTypes.func,
+  }
+
+  static defaultProps = {
+    portalNode: document.body,
+    usePortal: true,
   }
 
   onKeyDown = (event) => {
@@ -42,28 +48,17 @@ export default class Modal extends PureComponent {
     }
   }
 
-  render () {
+  renderModal = () => {
     const {
       children,
       className,
-      show,
-
       onCloseClick,
     } = this.props
 
-    if (!show) {
-      return null
-    }
-
-    const classes = cn({
-      [className]: className,
-      'mc-modal': true,
-    })
-
-    return createPortal(
+    return (
       <Provider value={{ close: this.close }}>
         <div
-          className={classes}
+          className={cn(className, 'mc-modal')}
           onKeyDown={this.onKeyDown}
           ref={this.container}
         >
@@ -84,8 +79,24 @@ export default class Modal extends PureComponent {
             </div>
           </div>
         </div>
-      </Provider>,
-      document.body,
+      </Provider>
     )
+  }
+
+  render () {
+    const {
+      show,
+      usePortal,
+      portalNode,
+    } = this.props
+
+    if (!show) {
+      return null
+    }
+
+    return usePortal ? createPortal(
+      this.renderModal(),
+      portalNode,
+    ) : this.renderModal()
   }
 }

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -100,6 +100,7 @@ export default class VideoPlayer extends PureComponent {
     this.video.off('pause')
     this.video.off('ended')
     this.video.off('seeking')
+    this.video.off('fullscreenchange')
     // remove DOM element
     this.video.dispose()
   }

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -35,6 +35,7 @@ export default class VideoPlayer extends PureComponent {
     onPause: PropTypes.func,
     onEnd: PropTypes.func,
     onTimeChange: PropTypes.func,
+    onFullscreenChange: PropTypes.func,
     onError: PropTypes.func,
     onSeek: PropTypes.func,
     progress: PropTypes.number,
@@ -131,6 +132,7 @@ export default class VideoPlayer extends PureComponent {
       }
     })
 
+    this.video.on('fullscreenchange', this.handleFullscreenChange)
     this.video.on('ended', this.handleVideoEnd)
 
     this.video.on('seeking', () => {
@@ -146,6 +148,7 @@ export default class VideoPlayer extends PureComponent {
         onVideoReady(this.video)
       }
     })
+
     if (onPlayerReady) {
       onPlayerReady(this.video)
     }
@@ -171,6 +174,13 @@ export default class VideoPlayer extends PureComponent {
 
     if (onEnd) {
       onEnd(this.video)
+    }
+  }
+
+  handleFullscreenChange = () => {
+    const { onFullscreenChange } = this.props
+    if (onFullscreenChange) {
+      onFullscreenChange(this.video.isFullscreen())
     }
   }
 


### PR DESCRIPTION
## Overview
- Added `appendToBody` to Modal to disable/enable react portal appending to body
- Added fullscreen event listener to VideoPlayer to toggle `appendToBody` in chapter video NPS survey

## Risks
None

## Changes
No changes, all new props are optional
