### PR TITLE
Modals

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -3,8 +3,6 @@ import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import cn from 'classnames'
 
-import IconClose from '../Icons/Close'
-
 
 const ModalContext = React.createContext('modal')
 
@@ -20,6 +18,7 @@ export default class Modal extends PureComponent {
       PropTypes.arrayOf(PropTypes.node),
     ]).isRequired,
     className: PropTypes.string,
+    closeButton: PropTypes.bool,
     show: PropTypes.bool,
     appendToBody: PropTypes.bool,
     onCloseClick: PropTypes.func,
@@ -59,7 +58,6 @@ export default class Modal extends PureComponent {
     const {
       children,
       className,
-      onCloseClick,
     } = this.props
 
     return (
@@ -70,16 +68,6 @@ export default class Modal extends PureComponent {
           ref={this.container}
         >
           <div className='mc-modal__backdrop' />
-
-          {onCloseClick &&
-            <div
-              className='mc-modal__close'
-              onClick={this.close('close')}
-            >
-              <IconClose />
-            </div>
-          }
-
           <div className='mc-modal__content-container'>
             <div className='mc-modal__content-container-inner'>
               {children}

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -21,7 +21,7 @@ export default class Modal extends PureComponent {
     closeButton: PropTypes.bool,
     show: PropTypes.bool,
     appendToBody: PropTypes.bool,
-    onCloseClick: PropTypes.func,
+    onClose: PropTypes.func,
   }
 
   static defaultProps = {
@@ -46,11 +46,11 @@ export default class Modal extends PureComponent {
 
   close = source => (event) => {
     const {
-      onCloseClick,
+      onClose,
     } = this.props
 
-    if (onCloseClick) {
-      onCloseClick(source, event)
+    if (onClose) {
+      onClose(source, event)
     }
   }
 

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -6,15 +6,17 @@ import CodeExample from '../../utils/CodeExample'
 
 import Modal from '../Modal'
 import ModalContent from '../ModalContent'
+import ModalClose from '../ModalClose'
+import InputField from '../InputField'
 import Button from '../Button'
+import Background from '../Background'
 import VideoPlayer from '../VideoPlayer'
 
 
 class ModalExample extends Component {
   state = {
-    large: false,
-    small: false,
-    full: false,
+    dialog: false,
+    cinema: false,
   }
 
   showModal = name => () => {
@@ -43,66 +45,114 @@ class ModalExample extends Component {
 
         <div className='example__section'>
           <CodeExample>
-            <div className='row'>
-              <div className='col-sm-auto'>
-                <Button onClick={this.showModal('small')}>
-                  Small
-                </Button>
+            <div className='mc-text--center'>
+              <Button
+                onClick={this.showModal('dialog')}
+                secondary
+              >
+                Open Dialog
+              </Button>
+            </div>
 
-                <Modal
-                  onCloseClick={this.hideModal('small')}
-                  show={this.state.small}
-                >
-                  <div className='container'>
-                    <div className='row'>
-                      <div className='col-sm-6 offset-sm-3'>
-                        <ModalContent>
-                          <div className='rounded-box'>
-                            <p>Content</p>
-                          </div>
-                        </ModalContent>
-                      </div>
+            <Modal
+              onCloseClick={this.hideModal('dialog')}
+              show={this.state.dialog}
+            >
+              <div className='container'>
+                <div className='row'>
+                  <div className='col-lg-4 offset-lg-4 col-md-6 offset-md-3 col-sm-8 offset-sm-2'>
+                    <ModalContent className='mc-invert'>
+                      <ModalClose />
+                      <Background
+                        color='light'
+                        className='mc-p-6'
+                      >
+                        <h6 className={`
+                          mc-text-h6
+                          mc-text--airy
+                          mc-text--center
+                          mc-text--hinted
+                          mc-mb-4
+                        `}>
+                          Register
+                        </h6>
+
+                        <InputField
+                          name='email'
+                          label='Email'
+                          placeholder='john@doe.com'
+                          input={{}}
+                          meta={{}}
+                          required
+                        />
+
+                        <InputField
+                          name='password'
+                          label='Password'
+                          placeholder='••••••••'
+                          input={{}}
+                          meta={{}}
+                          required
+                        />
+
+                        <p className={`
+                          mc-text-x-small
+                          mc-text--muted
+                          mc-text--center
+                          mc-mb-6
+                        `}>
+                          All your data are belong to us.
+                        </p>
+
+                        <Button fullWidth>
+                          Register
+                        </Button>
+                      </Background>
+                    </ModalContent>
+                  </div>
+                </div>
+              </div>
+            </Modal>
+          </CodeExample>
+
+          <CodeExample>
+            <div className='mc-text--center'>
+              <Button
+                onClick={this.showModal('cinema')}
+                secondary
+              >
+                Open Cinema Overlay
+              </Button>
+            </div>
+
+            <Modal
+              onCloseClick={this.hideModal('cinema')}
+              show={this.state.cinema}
+            >
+              <ModalClose />
+              <div className='container'>
+                <ModalContent>
+                  <div className='row align-items-center justify-content-between'>
+                    <div className='col-12'>
+                      <VideoPlayer hasAutoplay />
+                    </div>
+
+                    <div className='col-auto'>
+                      <h6 className='mc-text-h6 mc-text--uppercase'>
+                        Instructor Name
+                      </h6>
+                      <p className='mc-text--muted'>
+                        Teaches A Class
+                      </p>
+                    </div>
+
+                    <div className='col-auto'>
+                      <Button>All-Access Pass</Button>
                     </div>
                   </div>
-                </Modal>
+                </ModalContent>
               </div>
-
-              <div className='col-sm-auto'>
-                <Button onClick={this.showModal('large')}>
-                  Large
-                </Button>
-
-                <Modal
-                  onCloseClick={this.hideModal('large')}
-                  show={this.state.large}
-                >
-                  <div className='container'>
-                    <ModalContent>
-                      <div className='rounded-box'>
-                        <p>Content</p>
-                      </div>
-                    </ModalContent>
-                  </div>
-                </Modal>
-              </div>
-
-              <div className='col-sm-auto'>
-                <Button onClick={this.showModal('full')}>
-                  Full
-                </Button>
-
-                <Modal
-                  onCloseClick={this.hideModal('full')}
-                  show={this.state.full}
-                >
-                  <div className='container-fluid'>
-                    <ModalContent>
-                      <VideoPlayer hasAutoplay />
-                    </ModalContent>
-                  </div>
-                </Modal>
-              </div>
-            </div>
+            </Modal>
           </CodeExample>
         </div>
       </div>

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -55,7 +55,7 @@ class ModalExample extends Component {
             </div>
 
             <Modal
-              onCloseClick={this.hideModal('dialog')}
+              onClose={this.hideModal('dialog')}
               show={this.state.dialog}
             >
               <div className='container'>
@@ -126,7 +126,7 @@ class ModalExample extends Component {
             </div>
 
             <Modal
-              onCloseClick={this.hideModal('cinema')}
+              onClose={this.hideModal('cinema')}
               show={this.state.cinema}
             >
               <ModalClose />

--- a/src/components/ModalClose/index.js
+++ b/src/components/ModalClose/index.js
@@ -1,0 +1,22 @@
+import React, { PureComponent } from 'react'
+
+import { Consumer } from '../Modal'
+import IconClose from '../Icons/Close'
+
+
+export default class ModalClose extends PureComponent {
+  render () {
+    return (
+      <Consumer>
+        {({ close }) =>
+          <div
+            className='mc-modal__close'
+            onClick={close('close')}
+          >
+            <IconClose />
+          </div>
+        }
+      </Consumer>
+    )
+  }
+}

--- a/src/components/ModalContent/index.js
+++ b/src/components/ModalContent/index.js
@@ -35,17 +35,15 @@ export default class ModalContent extends PureComponent {
     return (
       <Consumer>
         {({ close }) =>
-          <div
-            className={classes}
-            ref={this.content}
-            tabIndex='-1'
-          >
-            <ClickOutside
-              onClickOutside={close('backdrop')}
+          <ClickOutside onClickOutside={close('backdrop')}>
+            <div
+              className={classes}
+              ref={this.content}
+              tabIndex='-1'
             >
               {children}
-            </ClickOutside>
-          </div>
+            </div>
+          </ClickOutside>
         }
       </Consumer>
     )

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -14,7 +14,7 @@
     top: 0;
     width: 100%;
     height: 100%;
-    background: rgba($mc-color-dark, 0.8);
+    background: rgba($mc-color-dark, 0.95);
     z-index: $mc-zindex-modal-backdrop;
   }
 
@@ -22,13 +22,17 @@
     position: absolute;
     right: 0;
     top: 0;
-    margin: 2rem;
-    padding: 1rem;
-    line-height: 1rem;
-    background: rgba($mc-color-dark, 0.5);
-    border-radius: 100%;
-    cursor: pointer;
+
+    @include step(margin, 4);
+    opacity: 0.5;
     z-index: $mc-zindex-modal + 2;
+    cursor: pointer;
+
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+    }
 
     svg {
       vertical-align: top;
@@ -55,6 +59,8 @@
   }
 
   &__content {
+    position: relative;
+
     &:focus {
       outline: none;
     }


### PR DESCRIPTION
## Overview
Implementing two types of modals as designed: dialog and cinema overlay.

This introduces an external `ModalClose` so that the positioning of the close button is more flexible (not a prop on `Modal` and/or `ModalContent`).

## Risks
Low - we'll need to update any existing Modal implementation, adding `ModalClose` where necessary.

## Changes
<img width="1250" alt="screen shot 2019-02-12 at 10 16 40 pm" src="https://user-images.githubusercontent.com/249444/52690865-e7b82580-2f13-11e9-82e1-ef77c2fdec72.png">
<img width="1250" alt="screen shot 2019-02-12 at 10 16 43 pm" src="https://user-images.githubusercontent.com/249444/52690874-e981e900-2f13-11e9-80a2-16ac62b9963e.png">