### PR TITLE
Incorporating libraries into main by default

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,5 +1,6 @@
 @import "base/base";
 @import "animation/animation";
+@import "libraries/libraries";
 @import "typography/typography";
 @import "components/components";
 @import "helpers/helpers";

--- a/src/styles/libraries/_libraries.scss
+++ b/src/styles/libraries/_libraries.scss
@@ -1,18 +1,4 @@
-// External or internal libraries
-
-// Reset
 @import "reset";
-
-// MC Variables
-@import "../base/variables";
-@import "../base/functions";
-@import "../base/mixins/mixins";
-
-// Bootstrap - the good parts
 @import "bootstrap-grid/bootstrap-grid";
-
-// Bootstrap overrides
 @import "bootstrap-overrides/grid";
-
-// Slick slider
 @import "slick-carousel/slick";


### PR DESCRIPTION
## Overview
libraries should be included at the root level, if you don't want them then you can import the stuff you do want.

## Risks
high, we'll need to change all instance that include libraries and the index separately
