### PR TITLE
Force storybook to load the introduction story first

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -17,6 +17,8 @@ setOptions({
 const req = require.context('../src', true, /\.stories\.js$/)
 
 function loadStories() {
+  // Force the introduction to load first!
+  require('../src/foundation/introduction/index.stories.js');
   req.keys().forEach((filename) => req(filename))
 }
 


### PR DESCRIPTION
## Overview
When loading storybook, force the "intro" summary story to load first.

## Risks
None - documentation update

## Changes
Now loads the summary / introduction story first instead of accordion.

## Issue
N/A
