### PR TITLE
Augmenting buttons within the video player to override the overrides (`.bc-player button`)

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -131,5 +131,20 @@ $container-max-widths: (
   xl: $mc-bp-xl + (2 * $container-margin-xl)
 ) !default;
 
+// Buttons
+$btn-kinds: (
+  "primary",
+  "secondary",
+  "tertiary",
+  "success",
+  "link",
+  "google",
+  "facebook",
+  "twitter",
+  "pinterest",
+  "paypal",
+  "applepay"
+) !default;
+
 // Forms
 $input-padding: 12px 16px !default;

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -35,6 +35,12 @@ $brightcove-video-sizes: (
   &__wrapper {
     padding-bottom: 56.25%;
   }
+
+  @each $kind in $btn-kinds {
+    .c-button--#{$kind} {
+      @extend .c-button--#{$kind};
+    }
+  }
 }
 
 .bc-player__video {


### PR DESCRIPTION
## Overview
Our Brightcove player overrides the `button` tag styles for some reason when player is fullscreen.  This override messes with our button styles because the selector is more specific (class + element) than our button styles selector (class).  This adds a more specific selector to the button styles (class + class) in addition to the original.

## Risks
None

## Changes
Buttons in video screens when the video player is in fullscreen mode render properly.