### PR TITLE
making sure the html font size stays as we set it

### DIFF
--- a/src/styles/base/mixins/_step.scss
+++ b/src/styles/base/mixins/_step.scss
@@ -1,11 +1,13 @@
-@mixin step($attribute, $value) {
-  #{$attribute}: calc-step($value, $mc-step-decay-sm) * 1rem;
+@mixin step($attribute, $value, $i: false) {
+  $important: if($i, "!important", "");
+
+  #{$attribute}: calc-step($value, $mc-step-decay-sm) * 1rem #{$important};
 
   @media (min-width: $mc-bp-md) {
-    #{$attribute}: calc-step($value, $mc-step-decay-md) * 1rem;
+    #{$attribute}: calc-step($value, $mc-step-decay-md) * 1rem #{$important};
   }
 
   @media (min-width: $mc-bp-lg) {
-    #{$attribute}: calc-step($value, $mc-step-decay-lg) * 1rem;
+    #{$attribute}: calc-step($value, $mc-step-decay-lg) * 1rem #{$important};
   }
 }

--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -3,7 +3,7 @@ html {
 }
 
 body {
-  @include step(font-size, 4);
+  @include step(font-size, 4, !important);
   font-weight: 400;
   font-family: $mc-font-default;
   font-variant-ligatures: none;

--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -1,4 +1,5 @@
 html {
+  /* stylelint-disable-next-line declaration-no-important */
   font-size: $mc-step-base * 1px !important;
 }
 

--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -1,5 +1,5 @@
 html {
-  font-size: $mc-step-base * 1px;
+  font-size: $mc-step-base * 1px !important;
 }
 
 body {


### PR DESCRIPTION
## Overview
All major measurements (anything using the step scale) is based in REM, and therefore `html { font-size: ____; }`.  We are forcing the value of this so that we can expect consistent sizing throughout the library.

## Risks
Low - if our application is expecting to be able to set the font-size of the `html` attribute anywhere, this will override it.  However, we are globally loading mc-components, and anywhere the app might be doing this would cause rendering issues anyway.

## Changes
Stuff ALWAYS renders properly