### PR TITLE
Improving label, error, and help text rendering when content is large

### DIFF
--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -40,21 +40,20 @@ export default class FormGroup extends PureComponent {
 
     return (
       <div className='mc-form-group mc-mb-5'>
-        <div className='row no-gutters justify-content-between align-items-end mc-mb-4'>
-          <div className='col-9'>
+        <div className='row no-gutters justify-content-between align-items-center mc-mb-4'>
+          <div className='col align-self-end'>
             {label &&
               <label
                 htmlFor={name}
                 className='d-block mc-text-h8 mc-mb-1'
               >
                 {label}
-
               </label>
             }
           </div>
 
           {optional &&
-            <div className='col-auto'>
+            <div className='col-auto align-self-end'>
               <p className='mc-text-x-small mc-text--silenced mc-mb-1'>
                 (Optional)
               </p>
@@ -65,26 +64,26 @@ export default class FormGroup extends PureComponent {
             {children}
           </div>
 
-          <div className='col-9'>
+          <div className='col align-self-start'>
             {showError &&
-              <span className='mc-text-x-small mc-text--error'>
+              <p className='mc-text-x-small mc-text--error mc-mt-1'>
                 <IconError />
                 {error}
-              </span>
+              </p>
             }
 
             {!showError &&
-              <span className='mc-text-x-small mc-text--muted'>
+              <p className='mc-text-x-small mc-text--muted mc-mt-1'>
                 {help}
-              </span>
+              </p>
             }
           </div>
 
-          <div className='col-auto'>
+          <div className='col-auto align-self-start'>
             {maxlength &&
-              <span className='mc-text-x-small mc-text--muted'>
+              <p className='mc-text-x-small mc-text--muted mc-mt-1'>
                 {value.length} / {maxlength}
-              </span>
+              </p>
             }
           </div>
         </div>

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -90,7 +90,10 @@ const Form = reduxForm({
             <Field
               component={TextareaField}
               name='bio'
-              label='Tell us about yourself'
+              label={`
+                Tell us about yourself. It could be anything or nothing at all,
+                but we prefer anything.
+              `}
               placeholder='This is the story of a girl...'
               optional
             />
@@ -128,8 +131,9 @@ const Form = reduxForm({
               type='password'
               label='Password'
               placeholder='••••••••'
+              help='The longer the password, the more secure it is. Also, try to make it unique...'
               prepend={<Lock />}
-              error='Password is required'
+              error='Password is required. Where else in the world have you logged in without a password?'
               maxlength={20}
             />
 

--- a/src/styles/libraries/bootstrap-overrides/_grid.scss
+++ b/src/styles/libraries/bootstrap-overrides/_grid.scss
@@ -22,6 +22,11 @@
   padding: $grid-gutter-width / 2;
 }
 
+.col-auto-max {
+  @extend .col-auto;
+  max-width: 100%;
+}
+
 // Responsive
 @media only screen and (min-width: $mc-bp-sm) {
   .container,


### PR DESCRIPTION
## Overview
Adjusting labels and support text for form groups to not be static width.

## Risks
None

## Changes

![labels](https://user-images.githubusercontent.com/249444/53769227-25afc600-3e90-11e9-81df-51f838c32581.gif)


## Issue
#380
