### PR TITLE
Adding showCount to Accordion

### DIFF
--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -1,6 +1,6 @@
-import React, { Children, PureComponent } from 'react'
+import React, { Children, Fragment, PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import { isArray, isFunction } from 'lodash'
+import { isArray, isFunction, times } from 'lodash'
 import cn from 'classnames'
 
 import HoverHandler from '../HoverHandler'
@@ -24,11 +24,13 @@ export default class Accordion extends PureComponent {
       'hovering',
       'intent',
     ]),
+    showCount: PropTypes.number,
   }
 
   static defaultProps = {
     aspectRatio: '21x9',
     on: 'hovering',
+    showCount: 4,
   }
 
   mapChildren = (children, mapFn) => {
@@ -45,6 +47,7 @@ export default class Accordion extends PureComponent {
       children,
       className,
       on,
+      showCount,
       ...restProps
     } = this.props
 
@@ -62,6 +65,8 @@ export default class Accordion extends PureComponent {
         'mc-accordion__item--active': active,
       })
 
+    const filled = times(showCount).map((v, i) => children[i])
+
     return (
       <HoverHandler nowrap>
         {({ [on]: parentActive, props: parentProps }) =>
@@ -71,14 +76,22 @@ export default class Accordion extends PureComponent {
             {...parentProps}
           >
             <div className='mc-accordion__content'>
-              {this.mapChildren(children, child =>
-                <HoverHandler nowrap>
-                  {({ [on]: itemActive, props: itemProps }) =>
-                    <div className={itemClasses(itemActive)} {...itemProps}>
-                      {renderChildren(child, { itemActive, parentActive })}
-                    </div>
+              {this.mapChildren(filled, (child, key) =>
+                <Fragment key={key}>
+                  {child &&
+                    <HoverHandler nowrap>
+                      {({ [on]: itemActive, props: itemProps }) =>
+                        <div className={itemClasses(itemActive)} {...itemProps}>
+                          {renderChildren(child, { itemActive, parentActive })}
+                        </div>
+                      }
+                    </HoverHandler>
                   }
-                </HoverHandler>,
+
+                  {!child &&
+                    <div className={itemClasses()} />
+                  }
+                </Fragment>,
               )}
             </div>
           </div>

--- a/src/components/Accordion/index.stories.js
+++ b/src/components/Accordion/index.stories.js
@@ -3,8 +3,10 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withProps } from '../../utils/addon-props'
+
 import DocHeader from '../../utils/DocHeader'
 import DocSection from '../../utils/DocSection'
+import PropExample from '../../utils/PropExample'
 import Placeholder from '../../utils/Placeholder'
 
 import Accordion from '../Accordion'
@@ -31,6 +33,7 @@ storiesOf('Components|Accordion', module)
             <Accordion
               className='mc-mb-10'
               aspectRatio={responsiveValues(media, '21x9', '16x9', '4x3')}
+              showCount={responsiveValues(media, 4, 3, 2)}
             >
               {[1, 2, 3, 4]
                 .slice(0, responsiveValues(media, 4, 3, 2))
@@ -48,6 +51,61 @@ storiesOf('Components|Accordion', module)
                 )
               }
             </Accordion>
+          </DocSection>
+
+          <DocSection title='Props'>
+            <PropExample
+              name='showCount'
+              type='Number'
+              description={`
+                Set the number of items to render.  If there are more, crop the
+                list.  If there are less, fill with empty panes.
+              `}
+            >
+              <Accordion
+                className='mc-mb-10'
+                aspectRatio={responsiveValues(media, '21x9', '16x9', '4x3')}
+                showCount={responsiveValues(media, 6, 5, 4)}
+              >
+                {[1, 2, 3, 4]
+                  .slice(0, responsiveValues(media, 4, 3, 2))
+                  .map(key =>
+                    ({ itemActive }) =>
+                      <Placeholder className='mc-text--center'>
+                        <h3 className='mc-text-h3'>
+                          {key}
+                        </h3>
+
+                        <p>
+                          {itemActive ? 'Active' : 'Inactive'}
+                        </p>
+                      </Placeholder>,
+                  )
+                }
+              </Accordion>
+
+              <Accordion
+                className='mc-mb-10'
+                aspectRatio={responsiveValues(media, '21x9', '16x9', '4x3')}
+                showCount={responsiveValues(media, 3, 2, 1)}
+              >
+                {[1, 2, 3, 4]
+                  .slice(0, responsiveValues(media, 4, 3, 2))
+                  .map(key =>
+                    ({ itemActive }) =>
+                      <Placeholder className='mc-text--center'>
+                        <h3 className='mc-text-h3'>
+                          {key}
+                        </h3>
+
+                        <p>
+                          {itemActive ? 'Active' : 'Inactive'}
+                        </p>
+                      </Placeholder>,
+                  )
+                }
+              </Accordion>
+            </PropExample>
           </DocSection>
         </div>
       }


### PR DESCRIPTION
## Overview
Adding prop to limit or fill the number of panes to show in an Accordion.

## Risks
Low - if someone is already using the Accordion, they might need to update the prop if their needs differ from standard usage.

## Changes
<img width="875" alt="Screen Shot 2019-03-14 at 3 57 13 PM" src="https://user-images.githubusercontent.com/249444/54396938-f6f4d500-4671-11e9-8888-232c27fef088.png">
<img width="832" alt="Screen Shot 2019-03-14 at 3 57 19 PM" src="https://user-images.githubusercontent.com/249444/54396941-f8be9880-4671-11e9-947d-80874f39fe65.png">


## Issue
#392
