### PR TITLE
Updating button padding to new design specs

### DIFF
--- a/src/styles/components/buttons/_button--types.scss
+++ b/src/styles/components/buttons/_button--types.scss
@@ -66,31 +66,31 @@
 
   &--tertiary {
     background: none;
-    border: 1px solid rgba($mc-color-light, 0.5);
+    box-shadow: inset 0 0 0 1px rgba($mc-color-light, 0.5);
 
     &:not(:disabled):not(.disabled) {
       &:hover {
         background: none;
-        border: 1px solid $mc-color-light;
+        box-shadow: inset 0 0 0 1px $mc-color-light;
       }
 
       &:active {
         background: none;
-        border: 1px solid rgba($mc-color-light, 0.5);
+        box-shadow: inset 0 0 0 1px rgba($mc-color-light, 0.5);
       }
     }
 
     .mc-invert & {
-      border: 1px solid rgba($mc-color-dark, 0.5);
+      box-shadow: inset 0 0 0 1px rgba($mc-color-dark, 0.5);
       color: $mc-color-dark;
 
       &:not(:disabled):not(.disabled) {
         &:hover {
-          border: 1px solid $mc-color-dark;
+          box-shadow: inset 0 0 0 1px $mc-color-dark;
         }
 
         &:active {
-          border: 1px solid rgba($mc-color-dark, 0.5);
+          box-shadow: inset 0 0 0 1px rgba($mc-color-dark, 0.5);
         }
       }
     }
@@ -246,7 +246,7 @@
     }
 
     .mc-invert & {
-      border: 1px solid #000;
+      box-shadow: inset 0 0 0 1px #000;
     }
   }
 }

--- a/src/styles/components/buttons/_button.scss
+++ b/src/styles/components/buttons/_button.scss
@@ -1,12 +1,15 @@
 .c-button,
 .mc-c-btn {
+  @include step(padding-top, 3);
+  @include step(padding-right, 5);
+  @include step(padding-bottom, 3);
+  @include step(padding-left, 5);
+  @include step(height, 9);
+  @include step(font-size, 3);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 1em 2em;
-  height: 4em;
   color: $mc-color-light;
-  font-size: 0.75em;
   font-weight: 700;
   line-height: 2;
   letter-spacing: 0.12em;
@@ -14,7 +17,7 @@
   border-radius: 4px;
   transition:
     background 250ms ease,
-    border 250ms ease,
+    box-shadow 250ms ease,
     opacity 250ms ease;
   vertical-align: middle;
 

--- a/src/styles/components/buttons/_button.scss
+++ b/src/styles/components/buttons/_button.scss
@@ -4,7 +4,6 @@
   @include step(padding-right, 5);
   @include step(padding-bottom, 3);
   @include step(padding-left, 5);
-  @include step(height, 9);
   @include step(font-size, 3);
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Overview
https://ourmasterclass.slack.com/archives/CB74RPL82/p1552516077019600

Design updated the padding on buttons, so this implements those new values, and ties them to the scale system (which didn't exist when buttons were first created! #progress)

## Risks
Low - the padding changes slightly so we'll have some shifting of button elements on the page, but nothing should be broken.

## Changes
Slightly narrower now!
![buttons](https://user-images.githubusercontent.com/505670/54455853-fca5f580-4719-11e9-9132-703bba321f6b.gif)

This also changes our buttons from using borders to using inset box shadows instead so we no longer have to worry about buttons shifting when they change from having no borders to borders like from this bug:
https://github.com/yankaindustries/mc-components/issues/379

## Issue
https://github.com/yankaindustries/mc-components/issues/400