### PR TITLE
Fix overflow on body for iOS devices caused by overflowing tile rows

### DIFF
--- a/src/styles/body/_body.scss
+++ b/src/styles/body/_body.scss
@@ -1,3 +1,8 @@
+html {
+  // For overflowing tile rows
+  overflow-x: hidden;
+}
+
 body {
   background: $mc-color-background;
   color: $mc-color-text;


### PR DESCRIPTION
## Overview
Fix the overflow of the body on iOS caused by tiles overflowing the row

## Risks
Low

## Changes
Fixes this:
![image](https://user-images.githubusercontent.com/505670/54457554-f8c8a200-471e-11e9-87da-36348d1fe763.png)

## Issue
https://github.com/yankaindustries/mc-components/issues/399