### PR TITLE
Forcing form group text alignments

### DIFF
--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -45,7 +45,7 @@ export default class FormGroup extends PureComponent {
             {label &&
               <label
                 htmlFor={name}
-                className='d-block mc-text-h8 mc-mb-1'
+                className='d-block mc-text-h8 mc-text--left mc-mb-1'
               >
                 {label}
               </label>
@@ -54,7 +54,7 @@ export default class FormGroup extends PureComponent {
 
           {optional &&
             <div className='col-auto align-self-end'>
-              <p className='mc-text-x-small mc-text--silenced mc-mb-1'>
+              <p className='mc-text-x-small mc-text--silenced mc-text--right mc-mb-1'>
                 (Optional)
               </p>
             </div>
@@ -66,14 +66,14 @@ export default class FormGroup extends PureComponent {
 
           <div className='col align-self-start'>
             {showError &&
-              <p className='mc-text-x-small mc-text--error mc-mt-1'>
+              <p className='mc-text-x-small mc-text--error mc-text--left mc-mt-1'>
                 <IconError />
                 {error}
               </p>
             }
 
             {!showError &&
-              <p className='mc-text-x-small mc-text--muted mc-mt-1'>
+              <p className='mc-text-x-small mc-text--muted mc-text--left mc-mt-1'>
                 {help}
               </p>
             }
@@ -81,7 +81,7 @@ export default class FormGroup extends PureComponent {
 
           <div className='col-auto align-self-start'>
             {maxlength &&
-              <p className='mc-text-x-small mc-text--muted mc-mt-1'>
+              <p className='mc-text-x-small mc-text--muted mc-text--right mc-mt-1'>
                 {value.length} / {maxlength}
               </p>
             }


### PR DESCRIPTION
## Overview
form labels and other text is often affected by text alignment set in a parent container.  we don't want to have to reset as these will always stay the same, so a simple override at the form group level works

## Risks
none
