### PR TITLE
Fix double body scrollbar

### DIFF
--- a/src/styles/body/_body.scss
+++ b/src/styles/body/_body.scss
@@ -6,5 +6,4 @@ html {
 body {
   background: $mc-color-background;
   color: $mc-color-text;
-  overflow-x: hidden;
 }


### PR DESCRIPTION
## Overview
The previous fix for the iOS scrolling issue introduced a new "double scrollbar" issue.  This PR consolidates the double overflow settings to just live on the `html` element which seems to fix the original issue on iOS and resolve the double scrollbar issue on desktop.

## Risks
Low

## Changes
### Before
![Screen Shot 2019-03-25 at 2 35 18 PM](https://user-images.githubusercontent.com/505670/54955696-3d1c2500-4f0b-11e9-82a0-e8d3b7173dbf.png)

### After
![Screen Shot 2019-03-25 at 2 35 16 PM](https://user-images.githubusercontent.com/505670/54955709-473e2380-4f0b-11e9-94e9-80d117c8e262.png)

## Issue
N/A
