### PR TITLE
temporarily fixing double subtitles/cc button

### DIFF
--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -204,7 +204,6 @@ $brightcove-video-sizes: (
     border-radius: 4px;
   }
 
-  // capitalize HD label
   .vjs-quality-menu-item-sub-label {
     text-transform: uppercase;
   }
@@ -240,7 +239,6 @@ $brightcove-video-sizes: (
     transform: translate3d(0, 0, 0) scaleY(0.75);
   }
 
-  // captialize subtitle options
   .vjs-captions-button,
   .vjs-subs-caps-button {
     .vjs-menu-item {
@@ -405,4 +403,9 @@ $brightcove-video-sizes: (
   } 100% {
     opacity: 1;
   }
+}
+
+// TODO JJ: Remove this when BC player is updated
+.vjs-captions-button {
+  display: none;
 }


### PR DESCRIPTION
## Overview
there is a bug on video players across the site where two cc icons are showing up (one subtitles, the other captions).  this is most likely due to brightcove forcing the version of our player to a newer one (that happens to contain this bug).  their solution is to update to a new major version, but that's a big undertaking (which we have started).  this is the temporary solution, brought to you by @a-axton 

## Risks
low - if for some reason a player only has the captions button, this could hide that.  not a terrible problem, and the bug appears to affect all players so i don't anticipate this actually being a problem

## Changes
from
<img width="338" alt="Screen Shot 2019-03-26 at 11 02 12 AM" src="https://user-images.githubusercontent.com/249444/55021802-a147f300-4fb6-11e9-8dae-f9d95b00b24b.png">
to
<img width="233" alt="Screen Shot 2019-03-26 at 11 00 31 AM" src="https://user-images.githubusercontent.com/249444/55021813-a3aa4d00-4fb6-11e9-87b8-88eef68a9ab2.png">

note that the cog icon removal isn't part of this, and is only a difference between local and prod