### PR TITLE
Update incorrect documentation terminology

### DIFF
--- a/src/foundation/scale/scale.stories.js
+++ b/src/foundation/scale/scale.stories.js
@@ -186,7 +186,7 @@ class Scale extends PureComponent {
 
           <Highlight className='language-scss mc-mb-8'>
 {`.some-container {
-  @include scale(padding, 5)
+  @include step(padding, 5)
 }`}
           </Highlight>
 


### PR DESCRIPTION
## Overview
@fsarachu noticed an error in the documentation around how to include the step mixin.  This corrects that issure.

## Risks
None, documentation change only