### PR TITLE
Video Player Styles Improvement

### DIFF
--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -317,10 +317,6 @@ $mc-video-progress-height: 0.8rem !default;
 
 
 // HIDE
-.vjs-custom-endscreen-overlay {
-  display: none !important;
-}
-
 .vjs-contextmenu-ui-menu {
   display: none;
 }


### PR DESCRIPTION
## Overview
This style was too broad, and not necessary.  Removing it will make custom endscreens (which I thought were only on actual VideoPlayer components) work properly on all legacy BC players

## Risks
Low
