### PR TITLE
Updating css selector to fix carousel highlight bugs

### DIFF
--- a/src/styles/components/carousel/_modifiers.scss
+++ b/src/styles/components/carousel/_modifiers.scss
@@ -22,7 +22,7 @@
 
   &--highlight-active {
     .slick-list {
-      .slick-slide {
+      .slick-active {
         opacity: 0.5;
         transition: opacity 250ms ease;
 
@@ -35,7 +35,7 @@
 
   &--highlight-hover {
     .slick-list:hover {
-      .slick-slide {
+      .slick-active {
         opacity: 0.5;
         transition: opacity 250ms ease;
 


### PR DESCRIPTION
## Overview
Carousel had some bugs with the `highlight` properties.  Because the css selector was on all slides, it was overriding the default css for "peek" attributes.

## Risks
Low

## Changes
### Before
![Screen Shot 2019-03-29 at 1 10 01 PM](https://user-images.githubusercontent.com/505670/55259846-0fddb880-5224-11e9-9c1b-13b927e51010.png)
### After
![Screen Shot 2019-03-29 at 1 10 27 PM](https://user-images.githubusercontent.com/505670/55259849-11a77c00-5224-11e9-8a71-f6ebd048deb8.png)

## Issue
https://github.com/yankaindustries/mc-components/issues/430