### PR TITLE
Update gradient-left values for Accordion's TileOverlay usecase

### DIFF
--- a/src/components/TileOverlay/index.js
+++ b/src/components/TileOverlay/index.js
@@ -54,8 +54,8 @@ export default class TileOverlay extends PureComponent {
         background: `
           linear-gradient(
             to right,
-            rgba(${color}, 1) 0,
-            rgba(${color}, 0.6) 25%,
+            rgba(${color}, 1) 12%,
+            rgba(${color}, 0.9) 20%,
             rgba(${color}, 0) 45%
           ) center no-repeat
         `,


### PR DESCRIPTION
## Overview
Update TileOverlay's gradient-left values to match Design's request for the Accordion usecase

## Risks
Low - only being used on new LIHP project's accordion component

## Changes
Before:
![image](https://user-images.githubusercontent.com/10948775/55262165-330b6680-522a-11e9-832d-a4195eafaf61.png)


After:
![image](https://user-images.githubusercontent.com/10948775/55262163-2f77df80-522a-11e9-9b00-3ab2c3e8ac17.png)

## Issue
https://github.com/yankaindustries/mc-components/issues/424
