### PR TITLE
Adding documentation for all aspect ratios

### DIFF
--- a/src/components/Accordion/index.stories.js
+++ b/src/components/Accordion/index.stories.js
@@ -107,6 +107,36 @@ storiesOf('Components|Accordion', module)
                 }
               </Accordion>
             </PropExample>
+
+
+            <PropExample
+              name='aspectRatio'
+              type='String'
+              description={`
+                auto, 1x1, 2x3, 3x4, 4x3, 9x16, 16x9
+              `}
+            >
+              <Accordion
+                className='mc-mb-10'
+                aspectRatio={responsiveValues(media, '1x1', '16x9', '16x9')}
+              >
+                {[1, 2, 3, 4]
+                  .slice(0, responsiveValues(media, 4, 3, 2))
+                  .map(key =>
+                    ({ itemActive }) =>
+                      <Placeholder className='mc-text--center'>
+                        <h3 className='mc-text-h3'>
+                          {key}
+                        </h3>
+
+                        <p>
+                          {itemActive ? 'Active' : 'Inactive'}
+                        </p>
+                      </Placeholder>,
+                  )
+                }
+              </Accordion>
+            </PropExample>
           </DocSection>
         </div>
       }

--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -247,6 +247,7 @@ storiesOf('Components|Tiles/Tile', module)
         <PropExample
           name='aspectRatio'
           type='String'
+          description='auto, 1x1, 2x3, 3x4, 4x3, 9x16, 16x9, 21x9'
         >
           <div className='row'>
             <div className='col-sm-12'>


### PR DESCRIPTION
## Overview
The supported aspect ratios for the `Accordion` and `Carousel` components weren't documented.

## Risks
None - documentation change only

## Changes
Adds listing of available aspect ratios to storybook examples for Accordion and Carousel

## Issue
https://github.com/yankaindustries/mc-components/issues/432