### PR TITLE
mute stops event bubbling so that you can click it and still have a Tile.onClick

### DIFF
--- a/src/components/TileVideo/index.js
+++ b/src/components/TileVideo/index.js
@@ -16,7 +16,7 @@ export default class TileVideo extends PureComponent {
     loop: PropTypes.bool,
     muted: PropTypes.bool,
     onVideoReady: PropTypes.func,
-    playerRef: PropTypes.obj,
+    playerRef: PropTypes.any,
     videoId: PropTypes.string.isRequired,
   }
 
@@ -44,6 +44,8 @@ export default class TileVideo extends PureComponent {
 
   onMuteClick = (event) => {
     event.preventDefault()
+    event.stopPropagation()
+
     this.setState(state => ({
       muted: !state.muted,
     }))

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -34,7 +34,7 @@ export default class VideoPlayer extends PureComponent {
     hasControls: PropTypes.bool,
     isLooped: PropTypes.bool,
     isMuted: PropTypes.bool,
-    playerRef: PropTypes.obj,
+    playerRef: PropTypes.any,
     progress: PropTypes.number,
 
     onPlayerReady: PropTypes.func,
@@ -106,7 +106,6 @@ export default class VideoPlayer extends PureComponent {
     this.video.off('seeking')
     this.video.off('fullscreenchange')
     this.video.off('loadmetadata')
-    this.video.dispose()
   }
 
   setupScript = () => {

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -233,6 +233,8 @@
 }
 
 .mc-tile-progress {
+  pointer-events: none;
+
   &__content {
     position: absolute;
     left: 0;


### PR DESCRIPTION
## Overview
TileVideo needs to `event.stopPropagation()` so that a `Tile.onClick` (or any parent, for that matter) isn't triggered when trying to mute.

## Risks
None