### PR TITLE
allowing autoplay for safari if the video is muted

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -184,13 +184,14 @@ export default class VideoPlayer extends PureComponent {
   handleReady = () => {
     const {
       hasAutoplay,
+      isMuted,
       onVideoReady,
     } = this.props
 
     this.checkBuffers()
     this.turnOffCaptions()
 
-    if (hasAutoplay && !isSafari) {
+    if (hasAutoplay && (!isSafari || isMuted)) {
       this.video.play()
     }
 


### PR DESCRIPTION
## Overview
safari has it's own restrictions on autoplaying videos if the video has audio.  however, safari allows videos that are muted to play, so we are updating our logic accordingly.  eventually this logic will be abstracted to autoplay feature detection, but until now this is a simple implementation

## Risks
None

## Issue
#107
