### PR TITLE
Form group/success

### DIFF
--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -3,6 +3,12 @@ import PropTypes from 'prop-types'
 import cn from 'classnames'
 
 import IconError from '../Icons/Error'
+import {
+  STATE_DEFAULT,
+  STATE_ERROR,
+  STATE_SUCCESS,
+} from '../Forms/constants'
+import { getState } from '../Forms/utils'
 
 
 export default class FormGroup extends PureComponent {
@@ -21,6 +27,10 @@ export default class FormGroup extends PureComponent {
     maxlength: PropTypes.number,
     name: PropTypes.string.isRequired,
     optional: PropTypes.bool,
+    success: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string),
+    ]),
     touched: PropTypes.bool,
     value: PropTypes.string,
   }
@@ -35,13 +45,15 @@ export default class FormGroup extends PureComponent {
       maxlength,
       name,
       optional,
+      success,
       touched,
       value,
     } = this.props
 
-    const showError = error && touched
+    const state = getState({ error, success, touched })
     const classes = cn({
       'mc-form-group': true,
+      [`mc-form-group--${state}`]: state,
       [className]: className,
     })
 
@@ -72,16 +84,22 @@ export default class FormGroup extends PureComponent {
           </div>
 
           <div className='col align-self-start'>
-            {showError &&
+            {state === STATE_DEFAULT &&
+              <p className='mc-text-x-small mc-text--muted mc-text--left mc-mt-1'>
+                {help}
+              </p>
+            }
+
+            {state === STATE_ERROR &&
               <p className='mc-text-x-small mc-text--error mc-text--left mc-mt-1'>
                 <IconError />
                 {error}
               </p>
             }
 
-            {!showError &&
-              <p className='mc-text-x-small mc-text--muted mc-text--left mc-mt-1'>
-                {help}
+            {state === STATE_SUCCESS &&
+              <p className='mc-text-x-small mc-text--success mc-text--left mc-mt-1'>
+                {success}
               </p>
             }
           </div>

--- a/src/components/Forms/constants.js
+++ b/src/components/Forms/constants.js
@@ -1,0 +1,3 @@
+export const STATE_DEFAULT = 'default'
+export const STATE_ERROR = 'error'
+export const STATE_SUCCESS = 'success'

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -41,6 +41,9 @@ const reducer = combineReducers({ form: formReducer })
 const store = createStore(reducer)
 const Form = reduxForm({
   form: 'summary',
+  initialValues: {
+    bio: 'Just a city boy, born and raised in South Detroit.',
+  },
 })(
   () =>
     <div className='example-mc-type'>
@@ -104,6 +107,7 @@ const Form = reduxForm({
                     but we prefer anything.
                   `}
                   placeholder='This is the story of a girl...'
+                  success='Dope!'
                   optional
                 />
               </div>
@@ -113,6 +117,7 @@ const Form = reduxForm({
                   className='mc-mb-4'
                   name='billing'
                   label='Billing Options'
+                  className='mc-mb-4'
                 >
                   <Field
                     component={RadioField}
@@ -191,7 +196,7 @@ const Form = reduxForm({
 
               <div className='col-12'>
                 <Field
-                  className='mc-mb-6'
+                  className='mc-mb-4'
                   component={CheckboxField}
                   name='newsletter'
                   label='I would like to sign up for the newsletter'

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -117,7 +117,6 @@ const Form = reduxForm({
                   className='mc-mb-4'
                   name='billing'
                   label='Billing Options'
-                  className='mc-mb-4'
                 >
                   <Field
                     component={RadioField}

--- a/src/components/Forms/utils.js
+++ b/src/components/Forms/utils.js
@@ -1,0 +1,12 @@
+import {
+  STATE_DEFAULT,
+  STATE_ERROR,
+  STATE_SUCCESS,
+} from './constants'
+
+
+export const getState = ({ error, success, touched }) => {
+  if (error && touched) return STATE_ERROR
+  if (success) return STATE_SUCCESS
+  return STATE_DEFAULT
+}

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import cn from 'classnames'
 
+import { getState } from '../Forms/utils'
+
 
 export default class Input extends PureComponent {
   static propTypes = {
@@ -73,9 +75,10 @@ export default class Input extends PureComponent {
       maxlength,
       name,
       prepend,
+      required,
+      success,
       touched,
       value,
-      required,
 
       onChange,
 
@@ -86,14 +89,13 @@ export default class Input extends PureComponent {
       focused,
     } = this.state
 
-    const showError = error && touched
-
+    const state = getState({ error, success, touched })
     const classes = cn({
       'mc-form-input': true,
       'mc-form-element': true,
       'mc-form-element--disabled': disabled,
-      'mc-form-element--error': showError,
       'mc-form-element--focus': focused,
+      [`mc-form-element--${state}`]: state,
     })
 
     return (

--- a/src/components/InputField/index.js
+++ b/src/components/InputField/index.js
@@ -5,19 +5,6 @@ import Input from '../Input'
 import FormGroup from '../FormGroup'
 
 
-const INPUT_PROP_TYPE = PropTypes.shape({
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.any.isRequired,
-})
-
-const META_PROP_TYPE = PropTypes.shape({
-  error: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
-  ]),
-})
-
 const parseError = (error) => {
   if (!Array.isArray(error)) {
     return error
@@ -36,6 +23,7 @@ const InputField = ({
   ...props
 }) => {
   const error = meta.error || props.error
+  const success = meta.success || props.success
   const touched = meta.touched || props.touched
 
   return (
@@ -47,12 +35,14 @@ const InputField = ({
       label={label}
       maxlength={maxlength}
       name={input.name}
-      touched={touched}
       optional={optional}
+      success={success}
+      touched={touched}
       value={input.value}
     >
       <Input
         error={parseError(error)}
+        success={success}
         touched={touched}
         {...input}
         {...props}
@@ -60,6 +50,19 @@ const InputField = ({
     </FormGroup>
   )
 }
+
+const INPUT_PROP_TYPE = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.any.isRequired,
+})
+
+const META_PROP_TYPE = PropTypes.shape({
+  error: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
+})
 
 InputField.propTypes = {
   className: PropTypes.string,

--- a/src/components/InputField/index.stories.js
+++ b/src/components/InputField/index.stories.js
@@ -35,77 +35,70 @@ const Form = reduxForm({
 
         <div className='example__section'>
           <InvertedMirror>
-            <div className='mc-mb-4'>
-              <Field
-                component={InputField}
-                name='default'
-                label='Label'
-                placeholder='Placeholder'
-              />
-            </div>
+            <Field
+              className='mc-mb-4'
+              component={InputField}
+              name='default'
+              label='Label'
+              placeholder='Placeholder'
+            />
 
             <hr />
 
-            <div className='mc-mb-4'>
-              <Field
-                component={InputField}
-                name='helper-text'
-                label='Helper Text'
-                placeholder='Placeholder'
-                help='Helper text'
-              />
-            </div>
+            <Field
+              className='mc-mb-4'
+              component={InputField}
+              name='helper-text'
+              label='Helper Text'
+              placeholder='Placeholder'
+              help='Helper text'
+            />
 
-            <div className='mc-mb-4'>
-              <Field
-                component={InputField}
-                name='optional'
-                label='Optional'
-                placeholder='Placeholder'
-                optional
-              />
-            </div>
+            <Field
+              className='mc-mb-4'
+              component={InputField}
+              name='optional'
+              label='Optional'
+              placeholder='Placeholder'
+              optional
+            />
 
-            <div className='mc-mb-4'>
-              <Field
-                component={InputField}
-                name='prepend'
-                label='Prepended Icon'
-                placeholder='Placeholder'
-                prepend={<MagnifyingGlass />}
-              />
-            </div>
+            <Field
+              className='mc-mb-4'
+              component={InputField}
+              name='prepend'
+              label='Prepended Icon'
+              placeholder='Placeholder'
+              prepend={<MagnifyingGlass />}
+            />
 
-            <div className='mc-mb-4'>
-              <Field
-                component={InputField}
-                name='append'
-                label='Appended Icon'
-                placeholder='Placeholder'
-                append={<Close />}
-              />
-            </div>
+            <Field
+              className='mc-mb-4'
+              component={InputField}
+              name='append'
+              label='Appended Icon'
+              placeholder='Placeholder'
+              append={<Close />}
+            />
 
-            <div className='mc-mb-4'>
-              <Field
-                component={InputField}
-                name='errors'
-                label='Error'
-                placeholder='Placeholder'
-                error='Error explanation'
-                touched
-              />
-            </div>
+            <Field
+              className='mc-mb-4'
+              component={InputField}
+              name='errors'
+              label='Error'
+              placeholder='Placeholder'
+              error='Error explanation'
+              touched
+            />
 
-            <div className='mc-mb-4'>
-              <Field
-                component={InputField}
-                name='disabled'
-                label='Disabled'
-                placeholder='Not clickable!'
-                disabled
-              />
-            </div>
+            <Field
+              className='mc-mb-4'
+              component={InputField}
+              name='disabled'
+              label='Disabled'
+              placeholder='Not clickable!'
+              disabled
+            />
           </InvertedMirror>
         </div>
       </div>

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -4,6 +4,8 @@ import cn from 'classnames'
 import { find } from 'lodash'
 import ReactSelect from 'react-select'
 
+import { getState } from '../Forms/utils'
+
 
 const PROP_TYPE_OPTION = PropTypes.shape({
   label: PropTypes.string.isRequired,
@@ -73,9 +75,11 @@ export default class Select extends PureComponent {
       label,
       name,
       options,
+      required,
+      success,
       touched,
       value,
-      required,
+
       onChange,
 
       ...props
@@ -85,14 +89,13 @@ export default class Select extends PureComponent {
       focused,
     } = this.state
 
-    const showError = error && touched
-
+    const state = getState({ error, success, touched })
     const classes = cn({
       'mc-form-select': true,
       'mc-form-element': true,
       'mc-form-element--disabled': disabled,
-      'mc-form-element--error': showError,
       'mc-form-element--focus': focused,
+      [`mc-form-element--${state}`]: state,
     })
 
     return (

--- a/src/components/SelectField/index.js
+++ b/src/components/SelectField/index.js
@@ -5,17 +5,6 @@ import Select from '../Select'
 import FormGroup from '../FormGroup'
 
 
-const INPUT_PROP_TYPE = PropTypes.shape({
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.any.isRequired,
-})
-
-const META_PROP_TYPE = PropTypes.shape({
-  error: PropTypes.string,
-})
-
-
 const SelectField = ({
   className,
   help,
@@ -27,6 +16,7 @@ const SelectField = ({
   ...props
 }) => {
   const error = meta.error || props.error
+  const success = meta.success || props.success
   const touched = meta.touched || props.touched
 
   return (
@@ -38,6 +28,7 @@ const SelectField = ({
       label={label}
       maxlength={maxlength}
       name={input.name}
+      success={success}
       touched={touched}
       optional={optional}
     >
@@ -50,6 +41,16 @@ const SelectField = ({
     </FormGroup>
   )
 }
+
+const INPUT_PROP_TYPE = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.any.isRequired,
+})
+
+const META_PROP_TYPE = PropTypes.shape({
+  error: PropTypes.string,
+})
 
 SelectField.propTypes = {
   className: PropTypes.string,

--- a/src/components/SelectField/index.stories.js
+++ b/src/components/SelectField/index.stories.js
@@ -11,6 +11,7 @@ import { storiesOf } from '@storybook/react'
 import withAddons from '../../utils/withAddons'
 import DocHeader from '../../utils/DocHeader'
 import InvertedMirror from '../../utils/InvertedMirror'
+
 import SelectField from '../SelectField'
 
 
@@ -42,7 +43,7 @@ const Form = reduxForm({
     <div className='container'>
       <DocHeader
         title='SelectField'
-        description='I agree to the terms...'
+        description='We got options people!'
       />
 
       <InvertedMirror>

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -2,6 +2,9 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import cn from 'classnames'
 
+import { getState } from '../Forms/utils'
+
+
 export default class Textarea extends PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
@@ -62,6 +65,7 @@ export default class Textarea extends PureComponent {
       error,
       label,
       name,
+      success,
       touched,
       value,
 
@@ -73,14 +77,13 @@ export default class Textarea extends PureComponent {
       focused,
     } = this.state
 
-    const showError = error && touched
-
+    const state = getState({ error, success, touched })
     const classes = cn({
       'mc-form-textarea': true,
       'mc-form-element': true,
       'mc-form-element--disabled': disabled,
-      'mc-form-element--error': showError,
       'mc-form-element--focus': focused,
+      [`mc-form-element--${state}`]: state,
     })
 
     return (

--- a/src/components/TextareaField/index.js
+++ b/src/components/TextareaField/index.js
@@ -5,17 +5,6 @@ import Textarea from '../Textarea'
 import FormGroup from '../FormGroup'
 
 
-const INPUT_PROP_TYPE = PropTypes.shape({
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.any.isRequired,
-})
-
-const META_PROP_TYPE = PropTypes.shape({
-  error: PropTypes.string,
-})
-
-
 const TextareaField = ({
   className,
   help,
@@ -27,6 +16,7 @@ const TextareaField = ({
   ...props
 }) => {
   const error = meta.error || props.error
+  const success = meta.success || props.success
   const touched = meta.touched || props.touched
 
   return (
@@ -38,8 +28,9 @@ const TextareaField = ({
       label={label}
       maxlength={maxlength}
       name={input.name}
-      touched={touched}
       optional={optional}
+      success={success}
+      touched={touched}
     >
       <Textarea
         error={error}
@@ -50,6 +41,16 @@ const TextareaField = ({
     </FormGroup>
   )
 }
+
+const INPUT_PROP_TYPE = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.any.isRequired,
+})
+
+const META_PROP_TYPE = PropTypes.shape({
+  error: PropTypes.string,
+})
 
 TextareaField.propTypes = {
   className: PropTypes.string,

--- a/src/components/TextareaField/index.stories.js
+++ b/src/components/TextareaField/index.stories.js
@@ -9,6 +9,7 @@ import {
 import { storiesOf } from '@storybook/react'
 
 import withAddons from '../../utils/withAddons'
+import DocHeader from '../../utils/DocHeader'
 import InvertedMirror from '../../utils/InvertedMirror'
 
 import TextareaField from '../TextareaField'
@@ -26,10 +27,10 @@ pretium consectetur risus eget feugiat. Ut faucibus id nunc vel tempor.`,
 })(
   () =>
     <div className='container'>
-      <div className='example__section'>
-        <h1 className='mc-text-h1'>Textarea</h1>
-        <p className='mc-text--muted'>Some various textareas...</p>
-      </div>
+      <DocHeader
+        title='TextareaField'
+        description='Some various textareas...'
+      />
 
       <div className='example__section'>
         <InvertedMirror>
@@ -62,6 +63,7 @@ pretium consectetur risus eget feugiat. Ut faucibus id nunc vel tempor.`,
           />
 
           <Field
+            className='mc-mb-4'
             component={TextareaField}
             name='disabled'
             label='Disabled'

--- a/src/styles/components/forms/_element.scss
+++ b/src/styles/components/forms/_element.scss
@@ -56,13 +56,19 @@
     }
   }
 
-  // Error states
-  // Eventually should be   .mc-form-group--error &
   &--error {
-    box-shadow: inset 0 0 0 2px $mc-color-primary;
+    box-shadow: inset 0 0 0 2px $mc-color-error;
 
     .mc-invert & {
-      box-shadow: inset 0 0 0 2px $mc-color-primary;
+      box-shadow: inset 0 0 0 2px $mc-color-error;
+    }
+  }
+
+  &--success {
+    box-shadow: inset 0 0 0 2px $mc-color-success;
+
+    .mc-invert & {
+      box-shadow: inset 0 0 0 2px $mc-color-success;
     }
   }
 

--- a/src/styles/components/forms/_structure.scss
+++ b/src/styles/components/forms/_structure.scss
@@ -1,3 +1,9 @@
+.mc-form-group {
+  svg {
+    margin: -0.5em;
+  }
+}
+
 .mc-form-prepend,
 .mc-form-append {
   display: flex;

--- a/src/styles/typography/_modifiers.scss
+++ b/src/styles/typography/_modifiers.scss
@@ -94,6 +94,7 @@
 
   // Colors
   &--error { color: $mc-color-error; }
+  &--success { color: $mc-color-success; }
 
   // Links
   &--link,


### PR DESCRIPTION
## Overview
Adding `success` to FormGroup and other form elements (input, textarea, select).  This will allow us to override `help` with a success message in green.

## Risks
None - just adding a new state

## Changes
<img width="588" alt="Screen Shot 2019-04-11 at 12 57 59 PM" src="https://user-images.githubusercontent.com/249444/55988705-75d13380-5c59-11e9-849f-0b7776fa8d57.png">

## Issue
#457