### PR TITLE
Forms - Constants / Utils Abstraction

### DIFF
--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -41,7 +41,7 @@ export default class Checkbox extends PureComponent {
       'mc-input-checkbox': true,
       'mc-input-checkbox--checked': checked,
       'mc-input-checkbox--disabled': disabled,
-      'mc-mb-5': true,
+      'mc-mb-2': true,
     })
 
     return (

--- a/src/components/CheckboxField/index.stories.js
+++ b/src/components/CheckboxField/index.stories.js
@@ -28,7 +28,7 @@ const Form = reduxForm({
     <div className='container'>
       <DocHeader
         title='CheckboxField'
-        description='I agree to the terms...'
+        description='For use with ReduxForm. I agree to the terms...'
       />
 
       <InvertedMirror>

--- a/src/components/CheckboxField/index.stories.js
+++ b/src/components/CheckboxField/index.stories.js
@@ -80,7 +80,7 @@ const Form = reduxForm({
 )
 
 
-storiesOf('Components|Forms/CheckboxField', module)
+storiesOf('Components|Forms/Checkbox', module)
   .add('CheckboxField', withAddons({
     path: 'components/CheckboxField/index.stories.js',
     component: CheckboxField,

--- a/src/components/Forms/constants.js
+++ b/src/components/Forms/constants.js
@@ -5,18 +5,20 @@ export const STATE_DEFAULT = 'default'
 export const STATE_ERROR = 'error'
 export const STATE_SUCCESS = 'success'
 
+const PROP_TYPE_MESSAGE = PropTypes.oneOfType([
+  PropTypes.bool,
+  PropTypes.string,
+])
+
 export const PROP_TYPE_INPUT = {
   disabled: PropTypes.bool,
-  error: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.string,
-  ]),
-  help: PropTypes.string,
+  error: PROP_TYPE_MESSAGE,
+  help: PROP_TYPE_MESSAGE,
   label: PropTypes.string,
   maxlength: PropTypes.number,
   name: PropTypes.string,
   value: PropTypes.string,
-  success: PropTypes.string,
+  success: PROP_TYPE_MESSAGE,
   touched: PropTypes.bool,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,

--- a/src/components/Forms/constants.js
+++ b/src/components/Forms/constants.js
@@ -1,3 +1,50 @@
+import PropTypes from 'prop-types'
+
+
 export const STATE_DEFAULT = 'default'
 export const STATE_ERROR = 'error'
 export const STATE_SUCCESS = 'success'
+
+export const PROP_TYPE_INPUT = {
+  disabled: PropTypes.bool,
+  error: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+  ]),
+  help: PropTypes.string,
+  label: PropTypes.string,
+  maxlength: PropTypes.number,
+  name: PropTypes.string,
+  value: PropTypes.string,
+  success: PropTypes.string,
+  touched: PropTypes.bool,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+}
+
+export const PROP_TYPE_OPTION = PropTypes.shape({
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+})
+
+export const PROP_TYPE_OPTIONS = PropTypes.arrayOf(PROP_TYPE_OPTION)
+
+export const PROP_TYPE_REDUX_FORM_INPUT = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.any.isRequired,
+})
+
+export const PROP_TYPE_REDUX_FORM_META = PropTypes.shape({
+  error: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
+})
+
+export const PROP_TYPE_REDUX_FORM_ELEMENT = {
+  className: PropTypes.string,
+  input: PROP_TYPE_REDUX_FORM_INPUT,
+  meta: PROP_TYPE_REDUX_FORM_META,
+}

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -117,7 +117,6 @@ const Form = reduxForm({
                   className='mc-mb-4'
                   name='billing'
                   label='Billing Options'
-                  className='mc-mb-4'
                 >
                   <Field
                     component={RadioField}
@@ -187,15 +186,12 @@ const Form = reduxForm({
 
               <div className='col-12'>
                 <Field
-                  className='mc-mb-4'
                   component={CheckboxField}
                   name='terms'
                   label='I agree to the terms'
                 />
-              </div>
-
-              <div className='col-12'>
                 <Field
+                  className='mc-mb-4'
                   component={CheckboxField}
                   name='newsletter'
                   label='I would like to sign up for the newsletter'

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -117,6 +117,7 @@ const Form = reduxForm({
                   className='mc-mb-4'
                   name='billing'
                   label='Billing Options'
+                  className='mc-mb-4'
                 >
                   <Field
                     component={RadioField}
@@ -195,7 +196,6 @@ const Form = reduxForm({
 
               <div className='col-12'>
                 <Field
-                  className='mc-mb-4'
                   component={CheckboxField}
                   name='newsletter'
                   label='I would like to sign up for the newsletter'

--- a/src/components/Forms/utils.js
+++ b/src/components/Forms/utils.js
@@ -11,9 +11,12 @@ export const getState = ({ error, success, touched }) => {
   return STATE_DEFAULT
 }
 
-export const parseError = (error) => {
-  if (!Array.isArray(error)) {
-    return error
+export const parseMessage = (message) => {
+  if (!Array.isArray(message)) {
+    return message
   }
-  return error.length > 0 ? error[0] : undefined
+
+  return message.length > 0
+    ? message[0]
+    : undefined
 }

--- a/src/components/Forms/utils.js
+++ b/src/components/Forms/utils.js
@@ -10,3 +10,10 @@ export const getState = ({ error, success, touched }) => {
   if (success) return STATE_SUCCESS
   return STATE_DEFAULT
 }
+
+export const parseError = (error) => {
+  if (!Array.isArray(error)) {
+    return error
+  }
+  return error.length > 0 ? error[0] : undefined
+}

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -57,8 +57,6 @@ export default class Input extends PureComponent {
       append,
       disabled,
       error,
-      // help,
-      // label,
       maxlength,
       name,
       prepend,

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -1,26 +1,13 @@
 import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
 import cn from 'classnames'
 
+import { PROP_TYPE_INPUT } from '../Forms/constants'
 import { getState } from '../Forms/utils'
 
 
 export default class Input extends PureComponent {
   static propTypes = {
-    disabled: PropTypes.bool,
-    error: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-    ]),
-    help: PropTypes.string,
-    label: PropTypes.string,
-    maxlength: PropTypes.number,
-    name: PropTypes.string,
-    value: PropTypes.string,
-    touched: PropTypes.bool,
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
+    ...PROP_TYPE_INPUT,
   }
 
   static defaultProps = {
@@ -70,8 +57,8 @@ export default class Input extends PureComponent {
       append,
       disabled,
       error,
-      help,
-      label,
+      // help,
+      // label,
       maxlength,
       name,
       prepend,

--- a/src/components/InputField/index.js
+++ b/src/components/InputField/index.js
@@ -1,16 +1,10 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import Input from '../Input'
 import FormGroup from '../FormGroup'
+import { parseError } from '../Forms/utils'
+import { PROP_TYPE_REDUX_FORM_ELEMENT } from '../Forms/constants'
 
-
-const parseError = (error) => {
-  if (!Array.isArray(error)) {
-    return error
-  }
-  return error.length > 0 ? error[0] : undefined
-}
 
 const InputField = ({
   className,
@@ -22,7 +16,7 @@ const InputField = ({
   optional,
   ...props
 }) => {
-  const error = meta.error || props.error
+  const error = parseError(meta.error || props.error)
   const success = meta.success || props.success
   const touched = meta.touched || props.touched
 
@@ -41,7 +35,7 @@ const InputField = ({
       value={input.value}
     >
       <Input
-        error={parseError(error)}
+        error={error}
         success={success}
         touched={touched}
         {...input}
@@ -51,23 +45,8 @@ const InputField = ({
   )
 }
 
-const INPUT_PROP_TYPE = PropTypes.shape({
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.any.isRequired,
-})
-
-const META_PROP_TYPE = PropTypes.shape({
-  error: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
-  ]),
-})
-
 InputField.propTypes = {
-  className: PropTypes.string,
-  input: INPUT_PROP_TYPE,
-  meta: META_PROP_TYPE,
+  ...PROP_TYPE_REDUX_FORM_ELEMENT,
 }
 
 export default InputField

--- a/src/components/InputField/index.js
+++ b/src/components/InputField/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Input from '../Input'
 import FormGroup from '../FormGroup'
-import { parseError } from '../Forms/utils'
+import { parseMessage } from '../Forms/utils'
 import { PROP_TYPE_REDUX_FORM_ELEMENT } from '../Forms/constants'
 
 
@@ -16,8 +16,8 @@ const InputField = ({
   optional,
   ...props
 }) => {
-  const error = parseError(meta.error || props.error)
-  const success = meta.success || props.success
+  const error = parseMessage(meta.error || props.error)
+  const success = parseMessage(meta.success || props.success)
   const touched = meta.touched || props.touched
 
   return (

--- a/src/components/InputField/index.stories.js
+++ b/src/components/InputField/index.stories.js
@@ -9,6 +9,7 @@ import {
 import { storiesOf } from '@storybook/react'
 
 import withAddons from '../../utils/withAddons'
+import DocHeader from '../../utils/DocHeader'
 import InvertedMirror from '../../utils/InvertedMirror'
 
 import InputField from '../InputField'
@@ -29,9 +30,10 @@ const Form = reduxForm({
   () =>
     <div className='example-mc-type'>
       <div className='container'>
-        <div className='example__heading'>
-          <h1 className='mc-text-h1'>InputField</h1>
-        </div>
+        <DocHeader
+          title='InputField'
+          description='For use with ReduxForm. The most basic of form elements.'
+        />
 
         <div className='example__section'>
           <InvertedMirror>

--- a/src/components/InputField/index.stories.js
+++ b/src/components/InputField/index.stories.js
@@ -106,7 +106,7 @@ const Form = reduxForm({
 )
 
 
-storiesOf('Components|Forms/InputField', module)
+storiesOf('Components|Forms/Input', module)
   .add('InputField', withAddons({
     path: 'components/InputField/index.stories.js',
     component: InputField,

--- a/src/components/RadioField/index.stories.js
+++ b/src/components/RadioField/index.stories.js
@@ -28,7 +28,7 @@ const Form = reduxForm({
     <div className='container'>
       <DocHeader
         title='RadioField'
-        description='Remember multiple choice?'
+        description='For use with ReduxForm. Remember multiple choice?'
       />
 
       <InvertedMirror>

--- a/src/components/RadioField/index.stories.js
+++ b/src/components/RadioField/index.stories.js
@@ -85,7 +85,7 @@ const Form = reduxForm({
 )
 
 
-storiesOf('Components|Forms/RadioField', module)
+storiesOf('Components|Forms/Radio', module)
   .add('RadioField', withAddons({
     path: 'components/RadioField/index.stories.js',
     component: RadioField,

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -1,34 +1,19 @@
 import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
 import cn from 'classnames'
 import { find } from 'lodash'
 import ReactSelect from 'react-select'
 
+import {
+  PROP_TYPE_INPUT,
+  PROP_TYPE_OPTIONS,
+} from '../Forms/constants'
 import { getState } from '../Forms/utils'
-
-
-const PROP_TYPE_OPTION = PropTypes.shape({
-  label: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-})
-
-const PROP_TYPE_OPTIONS = PropTypes.arrayOf(PROP_TYPE_OPTION)
 
 
 export default class Select extends PureComponent {
   static propTypes = {
-    disabled: PropTypes.bool,
-    error: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-    ]),
-    label: PropTypes.string,
-    name: PropTypes.string,
+    ...PROP_TYPE_INPUT,
     options: PROP_TYPE_OPTIONS.isRequired,
-    touched: PropTypes.bool,
-    value: PropTypes.string.isRequired,
-
-    onChange: PropTypes.func,
   }
 
   static defaultProps = {

--- a/src/components/SelectField/index.js
+++ b/src/components/SelectField/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import Select from '../Select'
 import FormGroup from '../FormGroup'
+import { parseError } from '../Forms/utils'
+import { PROP_TYPE_REDUX_FORM_ELEMENT } from '../Forms/constants'
 
 
 const SelectField = ({
@@ -15,7 +16,7 @@ const SelectField = ({
   optional,
   ...props
 }) => {
-  const error = meta.error || props.error
+  const error = parseError(meta.error || props.error)
   const success = meta.success || props.success
   const touched = meta.touched || props.touched
 
@@ -42,20 +43,8 @@ const SelectField = ({
   )
 }
 
-const INPUT_PROP_TYPE = PropTypes.shape({
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.any.isRequired,
-})
-
-const META_PROP_TYPE = PropTypes.shape({
-  error: PropTypes.string,
-})
-
 SelectField.propTypes = {
-  className: PropTypes.string,
-  input: INPUT_PROP_TYPE,
-  meta: META_PROP_TYPE,
+  ...PROP_TYPE_REDUX_FORM_ELEMENT,
 }
 
 export default SelectField

--- a/src/components/SelectField/index.js
+++ b/src/components/SelectField/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Select from '../Select'
 import FormGroup from '../FormGroup'
-import { parseError } from '../Forms/utils'
+import { parseMessage } from '../Forms/utils'
 import { PROP_TYPE_REDUX_FORM_ELEMENT } from '../Forms/constants'
 
 
@@ -16,8 +16,8 @@ const SelectField = ({
   optional,
   ...props
 }) => {
-  const error = parseError(meta.error || props.error)
-  const success = meta.success || props.success
+  const error = parseMessage(meta.error || props.error)
+  const success = parseMessage(meta.success || props.success)
   const touched = meta.touched || props.touched
 
   return (

--- a/src/components/SelectField/index.stories.js
+++ b/src/components/SelectField/index.stories.js
@@ -81,7 +81,7 @@ const Form = reduxForm({
 )
 
 
-storiesOf('Components|Forms/SelectField', module)
+storiesOf('Components|Forms/Select', module)
   .add('SelectField', withAddons({
     path: 'components/SelectField/index.stories.js',
     component: SelectField,

--- a/src/components/SelectField/index.stories.js
+++ b/src/components/SelectField/index.stories.js
@@ -43,7 +43,7 @@ const Form = reduxForm({
     <div className='container'>
       <DocHeader
         title='SelectField'
-        description='We got options people!'
+        description='For use with ReduxForm. We got options people!'
       />
 
       <InvertedMirror>

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -1,24 +1,13 @@
 import React, { PureComponent } from 'react'
-import PropTypes from 'prop-types'
 import cn from 'classnames'
 
+import { PROP_TYPE_INPUT } from '../Forms/constants'
 import { getState } from '../Forms/utils'
 
 
 export default class Textarea extends PureComponent {
   static propTypes = {
-    disabled: PropTypes.bool,
-    error: PropTypes.oneOfType([
-      PropTypes.bool,
-      PropTypes.string,
-    ]),
-    label: PropTypes.string,
-    name: PropTypes.string,
-    value: PropTypes.string,
-
-    onBlur: PropTypes.func,
-    onChange: PropTypes.func,
-    onFocus: PropTypes.func,
+    ...PROP_TYPE_INPUT,
   }
 
   static defaultProps = {

--- a/src/components/TextareaField/index.js
+++ b/src/components/TextareaField/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import Textarea from '../Textarea'
 import FormGroup from '../FormGroup'
+import { parseError } from '../Forms/utils'
+import { PROP_TYPE_REDUX_FORM_ELEMENT } from '../Forms/constants'
 
 
 const TextareaField = ({
@@ -15,7 +16,7 @@ const TextareaField = ({
   optional,
   ...props
 }) => {
-  const error = meta.error || props.error
+  const error = parseError(meta.error || props.error)
   const success = meta.success || props.success
   const touched = meta.touched || props.touched
 
@@ -42,20 +43,8 @@ const TextareaField = ({
   )
 }
 
-const INPUT_PROP_TYPE = PropTypes.shape({
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.any.isRequired,
-})
-
-const META_PROP_TYPE = PropTypes.shape({
-  error: PropTypes.string,
-})
-
 TextareaField.propTypes = {
-  className: PropTypes.string,
-  input: INPUT_PROP_TYPE,
-  meta: META_PROP_TYPE,
+  ...PROP_TYPE_REDUX_FORM_ELEMENT,
 }
 
 export default TextareaField

--- a/src/components/TextareaField/index.js
+++ b/src/components/TextareaField/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Textarea from '../Textarea'
 import FormGroup from '../FormGroup'
-import { parseError } from '../Forms/utils'
+import { parseMessage } from '../Forms/utils'
 import { PROP_TYPE_REDUX_FORM_ELEMENT } from '../Forms/constants'
 
 
@@ -16,8 +16,8 @@ const TextareaField = ({
   optional,
   ...props
 }) => {
-  const error = parseError(meta.error || props.error)
-  const success = meta.success || props.success
+  const error = parseMessage(meta.error || props.error)
+  const success = parseMessage(meta.success || props.success)
   const touched = meta.touched || props.touched
 
   return (

--- a/src/components/TextareaField/index.stories.js
+++ b/src/components/TextareaField/index.stories.js
@@ -76,7 +76,7 @@ pretium consectetur risus eget feugiat. Ut faucibus id nunc vel tempor.`,
 )
 
 
-storiesOf('Components|Forms/TextareaField', module)
+storiesOf('Components|Forms/Textarea', module)
   .add('TextareaField', withAddons({
     path: 'components/TextareaField/index.stories.js',
     component: TextareaField,

--- a/src/components/TextareaField/index.stories.js
+++ b/src/components/TextareaField/index.stories.js
@@ -29,7 +29,7 @@ pretium consectetur risus eget feugiat. Ut faucibus id nunc vel tempor.`,
     <div className='container'>
       <DocHeader
         title='TextareaField'
-        description='Some various textareas...'
+        description='For use with ReduxForm. Some various textareas...'
       />
 
       <div className='example__section'>


### PR DESCRIPTION
## Overview
So that we don't have to modify multiple places when adding functionality to form elements, the prop types and message parser are being abstracted to const/utils files.

There's also a slight improvement (heavy on _slight_) in documentation explaining form elements relative to ReduxForm.

## Risks
None - Nothing new, just a new place for the same things.