### PR TITLE
Adding default anchor link styles

### DIFF
--- a/src/styles/body/_body.scss
+++ b/src/styles/body/_body.scss
@@ -7,3 +7,17 @@ body {
   background: $mc-color-background;
   color: $mc-color-text;
 }
+
+// We want this behavior by default.
+a,
+a:hover {
+  text-decoration: none;
+}
+
+
+.mc-header {
+  a,
+  a:hover {
+    text-decoration: none;
+  }
+}

--- a/src/styles/body/_body.scss
+++ b/src/styles/body/_body.scss
@@ -13,11 +13,3 @@ a,
 a:hover {
   text-decoration: none;
 }
-
-
-.mc-header {
-  a,
-  a:hover {
-    text-decoration: none;
-  }
-}


### PR DESCRIPTION
## Overview
Adding default link styles to mc-components. Basically removes the default anchor underline.  This was previously in `mc-fe-styles`. Moving it here to consolidate.

## Risks
Low - some cases we might intend to have underlines, but having the default switch to "none" is low risk - they can be added back in where there's a noticed difference if needed.

## Changes
Links no longer have underlines by default.

## Issue
N/A
