### PR TITLE
Fix bug with modal not zindexing above content

### DIFF
--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -1,5 +1,6 @@
 .mc-modal {
   @include fade-in-opacity();
+  animation-fill-mode: none;
 
   position: fixed;
   left: 0;


### PR DESCRIPTION
## The problem
![image](https://user-images.githubusercontent.com/505670/56617977-1e768000-65d6-11e9-8601-c3f7acf60858.png)

In Safari, `mc-modal` was not laying on top of the body content correctly, with lower level z-indexed items somehow making their way on a higher layer. #soelevatedbro 

## The explanation
The core issue was how opacity and animation keyframes interact.  The default behavior of animation keyframes in css is to revert to the default styles on the element after the animation is finished.  In this case, it animates from `opacity: 0;`, to `opacity: 1;`, then back to having no opacity definitions at all (neither `0` nor `1`).

Our animation keyframe mixin was animating with the `animation-fill-mode` property set to `forwards`. This means that when the animation is complete, the css leaves the end value of the animation active (`opacity: 1`;).  

Unfortunately, when setting opacity on an element, you start a new `z-index` layer. While I'm not 100% sure on this, I believe what was happening was the element's `z-index: 1040;` was essentially ignored by the browser and reset back to 0.  This meant the nav bar and hero slider content would z-index above the mc-modal.


## The solution
I chose to resolve the issue by manually setting the animation fill mode on `mc-modal` to `none` (the default value).  This means that once the animation completes, the animated element returns back to the default values for opacity.  Since the `mc-modal` is created on the fly and not rendered on the page until ready for display, this has no negative effects, and does not affect any other implementations of the mixin.

## Risks
Low - tested with the modal on the homepage and gift pages in Safari, Firefox, and Chrome which all behave as expected now.

## Changes
N/A

## Issue
N/A
