### PR TITLE
Removing default background for VideoPlayer screens

### DIFF
--- a/src/components/VideoPlayer/index.stories.js
+++ b/src/components/VideoPlayer/index.stories.js
@@ -8,6 +8,7 @@ import DocSection from '../../utils/DocSection'
 import PropExample from '../../utils/PropExample'
 
 import VideoPlayer from './'
+import Background from '../Background'
 import Tile from '../Tile'
 import TileCaption from '../TileCaption'
 import TileImage from '../TileImage'
@@ -47,30 +48,36 @@ storiesOf('Components|VideoPlayer', module)
               hasControls
               beforescreenComponent={
                 ({ onResume }) =>
-                  <div style={screenStyle}>
-                    <p>Start playing your video</p>
-                    <button onClick={onResume}>
-                      START
-                    </button>
-                  </div>
+                  <Background color='dim' fit='container'>
+                    <div style={screenStyle}>
+                      <p>Start playing your video</p>
+                      <button onClick={onResume}>
+                        START
+                      </button>
+                    </div>
+                  </Background>
               }
               pausescreenComponent={
                 ({ onResume }) =>
-                  <div style={screenStyle}>
-                    <p>Your video is paused</p>
-                    <button onClick={onResume}>
-                      CONTINUE
-                    </button>
-                  </div>
+                  <Background color='dim' fit='container'>
+                    <div style={screenStyle}>
+                      <p>Your video is paused</p>
+                      <button onClick={onResume}>
+                        CONTINUE
+                      </button>
+                    </div>
+                  </Background>
               }
               endscreenComponent={
                 ({ onReplay }) =>
-                  <div style={screenStyle}>
-                    <p>Your video has ended</p>
-                    <button onClick={onReplay}>
-                      REPLAY
-                    </button>
-                  </div>
+                  <Background color='dim' fit='container'>
+                    <div style={screenStyle}>
+                      <p>Your video has ended</p>
+                      <button onClick={onReplay}>
+                        REPLAY
+                      </button>
+                    </div>
+                  </Background>
               }
             />
           </div>
@@ -137,12 +144,14 @@ storiesOf('Components|VideoPlayer', module)
               <VideoPlayer
                 beforescreenComponent={
                   ({ onResume }) =>
-                    <div style={screenStyle}>
-                      <p>Start playing your video</p>
-                      <button onClick={onResume}>
-                        START
-                      </button>
-                    </div>
+                    <Background color='dim' fit='container'>
+                      <div style={screenStyle}>
+                        <p>Start playing your video</p>
+                        <button onClick={onResume}>
+                          START
+                        </button>
+                      </div>
+                    </Background>
                 }
                 hasControls
               />
@@ -158,12 +167,14 @@ storiesOf('Components|VideoPlayer', module)
               <VideoPlayer
                 pausescreenComponent={
                   ({ onResume }) =>
-                    <div style={screenStyle}>
-                      <p>Your video is paused</p>
-                      <button onClick={onResume}>
-                        CONTINUE
-                      </button>
-                    </div>
+                    <Background color='dim' fit='container'>
+                      <div style={screenStyle}>
+                        <p>Your video is paused</p>
+                        <button onClick={onResume}>
+                          CONTINUE
+                        </button>
+                      </div>
+                    </Background>
                 }
                 hasControls
               />
@@ -180,12 +191,14 @@ storiesOf('Components|VideoPlayer', module)
                 progress={11}
                 endscreenComponent={
                   ({ onReplay }) =>
-                    <div style={screenStyle}>
-                      <p>Your video has ended</p>
-                      <button onClick={onReplay}>
-                        REPLAY
-                      </button>
-                    </div>
+                    <Background color='dim' fit='container'>
+                      <div style={screenStyle}>
+                        <p>Your video has ended</p>
+                        <button onClick={onReplay}>
+                          REPLAY
+                        </button>
+                      </div>
+                    </Background>
                 }
                 hasControls
               />

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -30,7 +30,6 @@ $mc-video-progress-height: 0.8rem !default;
     right: 0;
     bottom: 0;
     left: 0;
-    background: rgba($mc-color-dark, 0.7);
     opacity: 0;
     pointer-events: none;
     transition: 700ms ease-out;


### PR DESCRIPTION
## Overview
Removing the background of a VideoPlayer screen.  This way the implementor has complete control over how screens are displayed.

## Risks
Low - implementations need to be updated, this is easy with the recent changes to `<Background type='dim' fit='container' />`
