### PR TITLE
Fixing anchor styles on hover

### DIFF
--- a/src/foundation/typography/modifiers.stories.js
+++ b/src/foundation/typography/modifiers.stories.js
@@ -35,6 +35,8 @@ const Modifiers = () =>
           jumped over the
           {' '}
           <a className='mc-text--bare-link'>lazy dog</a>.
+          {' '}
+          <a>And this is an anchor without any classes.</a>
         </p>
       </PropExample>
     </DocSection>

--- a/src/styles/typography/_modifiers.scss
+++ b/src/styles/typography/_modifiers.scss
@@ -98,6 +98,7 @@
 
   // Links
   &--link,
+  &--link:hover,
   &--bare-link:hover,
   .mc-text--bare-link-parent:hover &--bare-link {
     text-decoration: underline;


### PR DESCRIPTION
## Overview
The storybook examples of link types had incorrect hover states.

## Risks
None

## Changes
Underline should no longer disappear on link types when hovered

## Issue
N/A
