### PR TITLE
Adding a rounded class helper and symmetrical icon styles

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -14,7 +14,8 @@ const Button = ({
   fullWidth,
   link,
   loading,
-  Icon,
+  symmetrical,
+  rounded,
   kind,
   ...props
 }) => {
@@ -26,6 +27,8 @@ const Button = ({
     'c-button--full-width': fullWidth,
     'c-button--link': link,
     'c-button--loading': loading,
+    'c-button--symmetrical': symmetrical,
+    'c-button--symmetrical mc-corners--circle': rounded,
     [`c-button--${kind}`]: kind,
   })
 
@@ -63,7 +66,7 @@ Button.propTypes = {
   fullWidth: PropTypes.bool,
   link: PropTypes.bool,
   loading: PropTypes.bool,
-  Icon: PropTypes.node,
+  symmetrical: PropTypes.bool,
   kind: PropTypes.oneOf([
     'primary',
     'secondary',

--- a/src/components/Button/index.stories.js
+++ b/src/components/Button/index.stories.js
@@ -8,15 +8,7 @@ import InvertedMirror from '../../utils/InvertedMirror'
 import PropExample from '../../utils/PropExample'
 
 import Button from '../Button'
-import IconGoogle from '../Icons/Google'
-import IconFacebook from '../Icons/Facebook'
-import IconPinterest from '../Icons/Pinterest'
-import IconTwitter from '../Icons/Twitter'
-import IconChevronRight from '../Icons/ChevronRight'
-import IconLock from '../Icons/Lock'
-import IconMagnifyingGlass from '../Icons/MagnifyingGlass'
-import IconClose from '../Icons/Close'
-
+import Icon from '../Icons'
 
 storiesOf('Components|Button', module)
   .add('Summary', withAddons({
@@ -79,25 +71,25 @@ storiesOf('Components|Button', module)
 
               <div className='col-auto'>
                 <Button kind='google'>
-                  <IconGoogle className='mc-mr-3' />
+                  <Icon kind='google' className='mc-mr-3' />
                   Google
                 </Button>
               </div>
               <div className='col-auto'>
                 <Button kind='facebook'>
-                  <IconFacebook className='mc-mr-3' />
+                  <Icon kind='facebook' className='mc-mr-3' />
                   Facebook
                 </Button>
               </div>
               <div className='col-auto'>
                 <Button kind='twitter'>
-                  <IconTwitter className='mc-mr-3' />
+                  <Icon kind='twitter' className='mc-mr-3' />
                   Twitter
                 </Button>
               </div>
               <div className='col-auto'>
                 <Button kind='pinterest'>
-                  <IconPinterest className='mc-mr-3' />
+                  <Icon kind='pinterest' className='mc-mr-3' />
                   Pinterest
                 </Button>
               </div>
@@ -183,39 +175,6 @@ storiesOf('Components|Button', module)
           </PropExample>
 
           <PropExample
-            name='icon'
-            type='children'
-          >
-            <div className='row'>
-              <div className='col-auto'>
-                <Button>
-                  Button
-                  <IconChevronRight className='mc-ml-3' />
-                </Button>
-              </div>
-
-              <div className='col-auto'>
-                <Button kind='secondary'>
-                  <IconLock className='mc-mr-3' />
-                  Secondary
-                </Button>
-              </div>
-
-              <div className='col-auto'>
-                <Button kind='tertiary'>
-                  <IconMagnifyingGlass />
-                </Button>
-              </div>
-
-              <div className='col-auto'>
-                <Button kind='link'>
-                  <IconClose />
-                </Button>
-              </div>
-            </div>
-          </PropExample>
-
-          <PropExample
             name='fullWidth'
             type='boolean'
           >
@@ -223,6 +182,102 @@ storiesOf('Components|Button', module)
               <div className='col-12'>
                 <Button fullWidth>
                   Full Width
+                </Button>
+              </div>
+            </div>
+          </PropExample>
+
+          <PropExample
+            name='symmetrical'
+            type='boolean'
+          >
+            <div className='row'>
+              <div className='col-auto'>
+                <Button symmetrical>
+                  <Icon kind='google' />
+                </Button>
+              </div>
+              <div className='col-auto'>
+                <Button kind='secondary' symmetrical>
+                  <Icon kind='plus' />
+                </Button>
+              </div>
+              <div className='col-auto'>
+                <Button kind='tertiary' symmetrical>
+                  <Icon kind='filter' />
+                </Button>
+              </div>
+              <div className='col-auto'>
+                <Button kind='link' symmetrical>
+                  <Icon kind='rewind' />
+                </Button>
+              </div>
+            </div>
+          </PropExample>
+
+          <PropExample
+            name='rounded'
+            type='boolean'
+          >
+            <div className='row'>
+              <div className='col-auto'>
+                <Button rounded>
+                  <Icon kind='google' />
+                </Button>
+              </div>
+              <div className='col-auto'>
+                <Button kind='secondary' rounded>
+                  <Icon kind='plus' />
+                </Button>
+              </div>
+              <div className='col-auto'>
+                <Button kind='tertiary' rounded>
+                  <Icon kind='filter' />
+                </Button>
+              </div>
+              <div className='col-auto'>
+                <Button kind='link' rounded>
+                  <Icon kind='rewind' />
+                </Button>
+              </div>
+            </div>
+          </PropExample>
+
+          <PropExample
+            name='Embedded Icons'
+          >
+
+            <div className='row'>
+              <div className='col-12'>
+                <p>
+                  You can embed icons using the
+                  <span className='mc-code'>Icon</span>
+                  component.
+                </p>
+              </div>
+              <div className='col-auto'>
+                <Button>
+                  Button
+                  <Icon kind='chevron-right' className='mc-ml-3' />
+                </Button>
+              </div>
+
+              <div className='col-auto'>
+                <Button kind='secondary'>
+                  <Icon kind='lock' className='mc-mr-3' />
+                  Secondary
+                </Button>
+              </div>
+
+              <div className='col-auto'>
+                <Button kind='tertiary'>
+                  <Icon kind='magnifying-glass' />
+                </Button>
+              </div>
+
+              <div className='col-auto'>
+                <Button kind='link'>
+                  <Icon kind='close' />
                 </Button>
               </div>
             </div>

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -152,3 +152,6 @@ $input-padding: 12px 16px !default;
 // Spacing
 $scale-begin: 0 !default;
 $scale-end: 12 !default;
+
+// Rounded to perfection
+$default-radius: 4px !default;

--- a/src/styles/components/_badge.scss
+++ b/src/styles/components/_badge.scss
@@ -4,7 +4,7 @@
   background: rgba($mc-color-gray-200, 0.5);
   color: $mc-color-light;
   padding: 0.25em 0.5em;
-  border-radius: 3px;
+  border-radius: $default-radius;
 
   &--primary {
     background: $mc-color-primary;

--- a/src/styles/components/_icons.scss
+++ b/src/styles/components/_icons.scss
@@ -28,7 +28,7 @@ svg {
   &--circled {
     padding: 0.25em;
     border: 1px solid currentColor;
-    border-radius: 100%;
+    border-radius: 50%;
   }
 
 

--- a/src/styles/components/_rounded-box.scss
+++ b/src/styles/components/_rounded-box.scss
@@ -1,6 +1,6 @@
 .rounded-box {
   background-color: $mc-color-light;
-  border-radius: 0.4rem;
+  border-radius: $default-radius;
   padding: $grid-gutter-width;
   color: $mc-color-dark;
 

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -250,13 +250,13 @@ $mc-video-progress-height: 0.8rem !default;
       text-shadow: none !important;
 
       &:first-child {
-        border-top-right-radius: 4px;
-        border-top-left-radius: 4px;
+        border-top-right-radius: $default-radius;
+        border-top-left-radius: $default-radius;
       }
 
       &:last-child {
-        border-bottom-right-radius: 4px;
-        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: $default-radius;
+        border-bottom-left-radius: $default-radius;
       }
 
       &.vjs-selected {

--- a/src/styles/components/buttons/_buttons.scss
+++ b/src/styles/components/buttons/_buttons.scss
@@ -12,7 +12,7 @@
   line-height: 2;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  border-radius: 4px;
+  border-radius: $default-radius;
   transition:
     background 250ms ease,
     box-shadow 250ms ease,

--- a/src/styles/components/buttons/_buttons.scss
+++ b/src/styles/components/buttons/_buttons.scss
@@ -174,6 +174,10 @@
     }
   }
 
+  &--symmetrical {
+    @include step(padding, 3);
+  }
+
   &--google {
     background-color: $mc-color-google;
 

--- a/src/styles/components/forms/_checkbox.scss
+++ b/src/styles/components/forms/_checkbox.scss
@@ -13,7 +13,7 @@
     width: 20px;
     height: 20px;
     background: $mc-color-gray-100;
-    border-radius: 4px;
+    border-radius: $default-radius;
     box-shadow: inset 0 0 0 1px $mc-color-gray-200;
     transition:
       background 250ms ease,

--- a/src/styles/components/forms/_element.scss
+++ b/src/styles/components/forms/_element.scss
@@ -3,7 +3,7 @@
   align-items: center;
   box-shadow: inset 0 0 0 1px $mc-color-gray-200;
   background: $mc-color-gray-100;
-  border-radius: 4px;
+  border-radius: $default-radius;
   width: 100%;
   cursor: text;
   transition:

--- a/src/styles/helpers/_corners.scss
+++ b/src/styles/helpers/_corners.scss
@@ -1,6 +1,6 @@
 .mc-corners {
   &--rounded {
-    border-radius: 4px;
+    border-radius: $default-radius;
   }
 
   &--circle {

--- a/src/styles/helpers/_corners.scss
+++ b/src/styles/helpers/_corners.scss
@@ -1,0 +1,13 @@
+.mc-corners {
+  &--rounded {
+    border-radius: 4px;
+  }
+
+  &--circle {
+    border-radius: 50%;
+  }
+
+  &--square {
+    border-radius: 0;
+  }
+}

--- a/src/styles/helpers/_helpers.scss
+++ b/src/styles/helpers/_helpers.scss
@@ -2,3 +2,4 @@
 @import "grid";
 @import "spacing-margin";
 @import "spacing-padding";
+@import "corners";


### PR DESCRIPTION
## Overview
Adds a "symmetrical" and "rounded" property to the button component:
![image](https://user-images.githubusercontent.com/505670/57050077-ab04ec00-6c2f-11e9-82e2-0aac27817bf1.png)

The rounded property can also be added to any image or block element with `.mc-corners--circle`

## Risks
None

## Changes
- Updated buttons to have "symmetrical" padding when that property is set
- Added new helper class to set any block element to have a full border radius (maybe avatars in the future?)

## Issue
N/A