### PR TITLE
Expanding line helper support

### DIFF
--- a/src/foundation/typography/modifiers.stories.js
+++ b/src/foundation/typography/modifiers.stories.js
@@ -102,13 +102,17 @@ const Modifiers = () =>
 
     <DocSection
       title='Lines'
-      description={`
-        We can max the number of lines a paragraph will have so that it better
-        fits smaller areas, and brings consistency to block heights. It even
-        works when the window is resized. The sample text used is much longer
-        than number of lines needed for demonstrative purposes.
-      `}
     >
+      <p className='mc-mb-8'>
+        This helper brings consistency to block heights. It even
+        works when the window is resized. The sample text used is much longer
+        than number of lines needed for demonstrative purposes. The main differences between <span className='mc-code'>--1-line</span>
+        and <span className='mc-code'>--1-line-max</span> is whether the space
+        the text occupies is collapsed or not.  You can see an example in the
+        <span className='mc-code'>--2-lines</span> section of each example
+        below.
+      </p>
+
       <div className='row'>
         <div className='col-4'>
           <PropExample name='.mc-text--1-line'>
@@ -137,6 +141,10 @@ const Modifiers = () =>
 
         <div className='col-4'>
           <PropExample name='.mc-text--2-lines'>
+            <p className='mc-text-large mc-text--2-lines'>
+              This holds two lines of space.
+            </p>
+
             <h4 className='mc-text-h4 mc-text--2-lines mc-mb-4'>
               This is a heading: Four score and seven years ago our
               fathers brought forth on this continent, a new nation,
@@ -162,6 +170,10 @@ const Modifiers = () =>
 
         <div className='col-4'>
           <PropExample name='.mc-text--3-lines'>
+            <p className='mc-text-large mc-text--3-lines'>
+              This holds three lines of space.
+            </p>
+
             <h4 className='mc-text-h4 mc-text--3-lines mc-mb-4'>
               This is a heading: Four score and seven years ago our
               fathers brought forth on this continent, a new nation,
@@ -177,6 +189,91 @@ const Modifiers = () =>
             </p>
 
             <p className='mc-text-large mc-text--3-lines'>
+              This is mc-text-large: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </p>
+          </PropExample>
+        </div>
+      </div>
+
+      <div className='row'>
+        <div className='col-4'>
+          <PropExample name='.mc-text--1-line-max'>
+            <h4 className='mc-text-h4 mc-text--1-line-max mc-mb-4'>
+              This is a heading: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </h4>
+
+            <p className='mc-text--1-line-max mc-mb-4'>
+              This is body text: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </p>
+
+            <p className='mc-text-large mc-text--1-line-max'>
+              This is mc-text-large: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </p>
+          </PropExample>
+        </div>
+
+        <div className='col-4'>
+          <PropExample name='.mc-text--2-lines-max'>
+            <p className='mc-text-large mc-text--2-lines-max'>
+              This line collapses.
+            </p>
+
+            <h4 className='mc-text-h4 mc-text--2-lines-max mc-mb-4'>
+              This is a heading: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </h4>
+
+            <p className='mc-text--2-lines-max mc-mb-4'>
+              This is body text: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </p>
+
+            <p className='mc-text-large mc-text--2-lines-max'>
+              This is mc-text-large: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </p>
+          </PropExample>
+        </div>
+
+        <div className='col-4'>
+          <PropExample name='.mc-text--3-lines-max'>
+            <p className='mc-text-large mc-text--3-lines-max'>
+              This line collapses.
+            </p>
+
+            <h4 className='mc-text-h4 mc-text--3-lines-max mc-mb-4'>
+              This is a heading: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </h4>
+
+            <p className='mc-text--3-lines-max mc-mb-4'>
+              This is body text: Four score and seven years ago our
+              fathers brought forth on this continent, a new nation,
+              conceived in Liberty, and dedicated to the proposition
+              that all men are created equal.
+            </p>
+
+            <p className='mc-text-large mc-text--3-lines-max'>
               This is mc-text-large: Four score and seven years ago our
               fathers brought forth on this continent, a new nation,
               conceived in Liberty, and dedicated to the proposition

--- a/src/styles/typography/_modifiers.scss
+++ b/src/styles/typography/_modifiers.scss
@@ -25,13 +25,17 @@
   }
 
   &--1-line,
+  &--1-line-max,
   &--2-lines,
-  &--3-lines {
+  &--2-lines-max,
+  &--3-lines,
+  &--3-lines-max {
     display: block;
     overflow: hidden;
   }
 
-  &--1-line {
+  &--1-line,
+  &--1-line-max {
     text-overflow: ellipsis;
     white-space: nowrap;
 
@@ -57,7 +61,34 @@
     }
   }
 
-  &--2-lines {
+  &--1-line-max {
+    height: auto;
+    max-height: #{$mc-lh-md}em;
+
+    // Headings
+    &[class^="mc-text-h"],
+    [class^="mc-text-h"] & {
+      height: auto;
+      max-height: #{$mc-lh-sm}em;
+    }
+
+    // Small text
+    &.mc-text-small,
+    .mc-text-small & {
+      height: auto;
+      max-height: #{$mc-lh-sm}em;
+    }
+
+    // Large text
+    &.mc-text-large,
+    .mc-text-large & {
+      height: auto;
+      max-height: #{$mc-lh-lg}em;
+    }
+  }
+
+  &--2-lines,
+  &--2-lines-max {
     // Default body / anything not defined
     height: #{2 * $mc-lh-md}em;
 
@@ -80,7 +111,35 @@
     }
   }
 
-  &--3-lines {
+  &--2-lines-max {
+    // Default body / anything not defined
+    height: auto;
+    max-height: #{2 * $mc-lh-md}em;
+
+    // Headings
+    &[class^="mc-text-h"],
+    [class^="mc-text-h"] & {
+      height: auto;
+      max-height: #{2 * $mc-lh-sm}em;
+    }
+
+    // Small text
+    &.mc-text-small,
+    .mc-text-small & {
+      height: auto;
+      max-height: #{2 * $mc-lh-sm}em;
+    }
+
+    // Large text
+    &.mc-text-large,
+    .mc-text-large & {
+      height: auto;
+      max-height: #{2 * $mc-lh-lg}em;
+    }
+  }
+
+  &--3-lines,
+  &--3-lines-max {
     // Default body / anything not defined
     height: #{3 * $mc-lh-md}em;
 
@@ -100,6 +159,33 @@
     &.mc-text-large,
     .mc-text-large & {
       height: #{3 * $mc-lh-lg}em;
+    }
+  }
+
+  &--3-lines-max {
+    // Default body / anything not defined
+    height: auto;
+    max-height: #{3 * $mc-lh-md}em;
+
+    // Headings
+    &[class^="mc-text-h"],
+    [class^="mc-text-h"] & {
+      height: auto;
+      max-height: #{3 * $mc-lh-sm}em;
+    }
+
+    // Small text
+    &.mc-text-small,
+    .mc-text-small & {
+      height: auto;
+      max-height: #{3 * $mc-lh-sm}em;
+    }
+
+    // Large text
+    &.mc-text-large,
+    .mc-text-large & {
+      height: auto;
+      max-height: #{3 * $mc-lh-lg}em;
     }
   }
 


### PR DESCRIPTION
## Overview
Added additional line helpers for "max-height" lines.  This is useful if you want to have three lines of text truncated, but NOT have it take up the three lines of height.

## Risks
None

## Changes
![image](https://user-images.githubusercontent.com/505670/59235960-dec91f00-8ba8-11e9-86f8-6e0bebc9ad60.png)

## Issue
https://github.com/yankaindustries/mc-components/issues/493