### PR TITLE
only include media queries in step mixin if they are needed

### DIFF
--- a/src/styles/base/mixins/_step.scss
+++ b/src/styles/base/mixins/_step.scss
@@ -1,13 +1,20 @@
 @mixin step($attribute, $value, $i: false) {
   $important: if($i, "!important", "");
+  $calc-sm: calc-step($value, $mc-step-decay-sm);
+  $calc-md: calc-step($value, $mc-step-decay-md);
+  $calc-lg: calc-step($value, $mc-step-decay-lg);
 
-  #{$attribute}: calc-step($value, $mc-step-decay-sm) * 1rem #{$important};
+  #{$attribute}: $calc-sm * 1rem #{$important};
 
-  @media (min-width: $mc-bp-md) {
-    #{$attribute}: calc-step($value, $mc-step-decay-md) * 1rem #{$important};
+  @if $calc-md != $calc-sm {
+    @media (min-width: $mc-bp-md) {
+      #{$attribute}: $calc-md * 1rem #{$important};
+    }
   }
 
-  @media (min-width: $mc-bp-lg) {
-    #{$attribute}: calc-step($value, $mc-step-decay-lg) * 1rem #{$important};
+  @if $calc-lg != $calc-sm {
+    @media (min-width: $mc-bp-lg) {
+      #{$attribute}: $calc-lg * 1rem #{$important};
+    }
   }
 }


### PR DESCRIPTION
## Overview
Our step mixin was including breakpoints for values that remained the same for lower values. This added extra media queries that didn't need to be there.

## Risks
None