### PR TITLE
Changing opacity helper naming

### DIFF
--- a/src/components/AnimationHandler/index.stories.js
+++ b/src/components/AnimationHandler/index.stories.js
@@ -96,7 +96,7 @@ storiesOf('utilities|AnimationHandler', module)
                       <h2 className='mc-text-h2 mc-text--uppercase'>
                         Shonda Rhimes
                       </h2>
-                      <h4 className='mc-text-h4 mc-text--uppercase mc-text--muted mc-text--normal mc-text--airy'>
+                      <h4 className='mc-text-h4 mc-text--uppercase mc-opacity--muted mc-text--normal mc-text--airy'>
                         Teaches Writing for Television
                       </h4>
                     </TileCaption>

--- a/src/components/Background/index.stories.js
+++ b/src/components/Background/index.stories.js
@@ -52,7 +52,7 @@ storiesOf('Components|Background', module)
 
                   <br />
 
-                  <p className='mc-text--muted'>
+                  <p className='mc-opacity--muted'>
                     Chef Thomas Keller is the only American chef to hold
                     multiple Michelin three-star ratings. In his MasterClass,
                     the chef behind The French Laundry teaches you the
@@ -85,7 +85,7 @@ storiesOf('Components|Background', module)
                     Learn From The Best
                   </h2>
 
-                  <p className='mc-text--muted mc-mb-5'>
+                  <p className='mc-opacity--muted mc-mb-5'>
                     Visit our blog for a deeper dive
                     into all things MasterClass.
                   </p>

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -80,7 +80,7 @@ const tiles = () =>
           <h6 className='mc-text-h6 mc-text--uppercase'>
             {item.instructor}
           </h6>
-          <h6 className='mc-text-h8 mc-text--airy mc-text--muted'>
+          <h6 className='mc-text-h8 mc-text--airy mc-opacity--muted'>
             {item.teaches}
           </h6>
         </TileCaption>
@@ -126,10 +126,10 @@ storiesOf('Components|Carousels', module)
                             <h2 className='mc-text-h1 mc-text--uppercase'>
                               {item.instructor}
                             </h2>
-                            <h3 className='mc-text-h3 mc-text--muted mc-text--airy mc-mb-4'>
+                            <h3 className='mc-text-h3 mc-opacity--muted mc-text--airy mc-mb-4'>
                               Teaches {item.teaches}
                             </h3>
-                            <p className='mc-text-intro mc-text--hinted mc-mb-8'>
+                            <p className='mc-text-intro mc-opacity--hinted mc-mb-8'>
                               Online classes taught by the world&apos;s
                               greatest minds.<br /> Learn from
                               {item.instructor} and all 35+ other
@@ -173,7 +173,7 @@ storiesOf('Components|Carousels', module)
                             <h6 className='mc-text-h6 mc-text--uppercase'>
                               {item.instructor}
                             </h6>
-                            <h6 className='mc-text-h8 mc-text--airy mc-text--muted'>
+                            <h6 className='mc-text-h8 mc-text--airy mc-opacity--muted'>
                               {item.teaches}
                             </h6>
                           </TileCaption>

--- a/src/components/CarouselConnector/index.stories.js
+++ b/src/components/CarouselConnector/index.stories.js
@@ -76,7 +76,7 @@ const tiles = () =>
           <h6 className='mc-text-h6 mc-text--uppercase'>
             {item.instructor}
           </h6>
-          <h6 className='mc-text-h8 mc-text--airy mc-text--muted'>
+          <h6 className='mc-text-h8 mc-text--airy mc-opacity--muted'>
             {item.teaches}
           </h6>
         </TileCaption>

--- a/src/components/Dropdown/index.stories.js
+++ b/src/components/Dropdown/index.stories.js
@@ -113,7 +113,7 @@ class DropdownStory extends PureComponent {
                               </h5>
                               <p className={`
                                 mc-text-sm
-                                mc-text--muted
+                                mc-opacity--muted
                                 mc-text--3-lines
                               `}>
                                 Pellentesque auctor nibh eu justo condimentum,
@@ -141,7 +141,7 @@ class DropdownStory extends PureComponent {
                           mc-p-5
                           mc-text-h8
                           mc-text--uppercase
-                          mc-text--muted
+                          mc-opacity--muted
                           mc-text-center
                       `}>
                         Categories

--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -71,7 +71,7 @@ export default class FormGroup extends PureComponent {
 
           {optional &&
             <div className='col-auto align-self-end'>
-              <p className='mc-text-x-small mc-text--silenced mc-text--right mc-mb-1'>
+              <p className='mc-text-x-small mc-opacity--silenced mc-text--right mc-mb-1'>
                 (Optional)
               </p>
             </div>
@@ -83,7 +83,7 @@ export default class FormGroup extends PureComponent {
 
           <div className='col align-self-start'>
             {state === STATE_DEFAULT &&
-              <p className='mc-text-x-small mc-text--muted mc-text--left mc-mt-1'>
+              <p className='mc-text-x-small mc-opacity--muted mc-text--left mc-mt-1'>
                 {help}
               </p>
             }
@@ -104,7 +104,7 @@ export default class FormGroup extends PureComponent {
 
           <div className='col-auto align-self-start'>
             {maxlength &&
-              <p className='mc-text-x-small mc-text--muted mc-text--right mc-mt-1'>
+              <p className='mc-text-x-small mc-opacity--muted mc-text--right mc-mt-1'>
                 {value.length} / {maxlength}
               </p>
             }

--- a/src/components/HoverHandler/index.stories.js
+++ b/src/components/HoverHandler/index.stories.js
@@ -17,7 +17,7 @@ storiesOf('utilities|HoverHandler', module)
     <div className='container'>
       <div className='example__heading'>
         <h1 className='mc-text-h1'>HoverHandler</h1>
-        <p className='mc-text--muted'>
+        <p className='mc-opacity--muted'>
           Get access to hover as a property
         </p>
       </div>

--- a/src/components/Icons/index.stories.js
+++ b/src/components/Icons/index.stories.js
@@ -39,7 +39,7 @@ storiesOf('Components|Icons', module)
                 <div key={kind} className='col-3 mc-text--center'>
                   <Icon kind={kind} />
                   <br />
-                  <span className='mc-text-x-small mc-text--muted mc-text--nowrap'>
+                  <span className='mc-text-x-small mc-opacity--muted mc-text--nowrap'>
                     {kind}
                   </span>
                 </div>,

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -67,14 +67,14 @@ class ModalExample extends Component {
                       color='light'
                       className='mc-px-4 mc-py-9 mc-text--center'
                     >
-                      <h6 className='mc-text-h8 mc-text--airy mc-text--muted mc-mb-2'>
+                      <h6 className='mc-text-h8 mc-text--airy mc-opacity--muted mc-mb-2'>
                         You completed the playlist
                       </h6>
                       <h3 className='mc-text-h3 mc-mb-8'>
                         How did you like it?
                       </h3>
 
-                      <div className='mc-text--silenced mc-mb-6'>
+                      <div className='mc-opacity--silenced mc-mb-6'>
                         <Icon kind='starred' />
                         <Icon kind='starred' />
                         <Icon kind='starred' />
@@ -123,7 +123,7 @@ class ModalExample extends Component {
                             Payment Method
                           </h6>
 
-                          <p className='mc-text--muted mc-mb-4'>
+                          <p className='mc-opacity--muted mc-mb-4'>
                             Update your payment method to be used for your
                             future purchases.
                           </p>
@@ -253,7 +253,7 @@ class ModalExample extends Component {
                         <h6 className='mc-text-h6 mc-text--uppercase'>
                           Instructor Name
                         </h6>
-                        <p className='mc-text--muted'>
+                        <p className='mc-opacity--muted'>
                           Teaches A Class
                         </p>
                       </div>

--- a/src/components/ResponsiveHandler/index.stories.js
+++ b/src/components/ResponsiveHandler/index.stories.js
@@ -20,7 +20,7 @@ storiesOf('utilities|ResponsiveHandler', module)
     <div className='container'>
       <div className='example__heading'>
         <h1 className='mc-text-h1'>ResponsiveHandler</h1>
-        <p className='mc-text--muted'>
+        <p className='mc-opacity--muted'>
           Get access to screen size as a prop
         </p>
       </div>

--- a/src/components/Tile/index.stories.js
+++ b/src/components/Tile/index.stories.js
@@ -56,7 +56,7 @@ storiesOf('Components|Tiles', module)
                 <h5 className='mc-text-h5'>
                   Shonda Rhimes
                 </h5>
-                <p className='mc-text--muted'>
+                <p className='mc-opacity--muted'>
                   Teaches Writing
                 </p>
               </TileCaption>
@@ -127,7 +127,7 @@ storiesOf('Components|Tiles', module)
                             <h5 className='mc-text-h5'>
                               Shonda Rhimes
                             </h5>
-                            <p className='mc-text--muted'>
+                            <p className='mc-opacity--muted'>
                               Teaches Writing
                             </p>
                           </TileCaption>
@@ -174,7 +174,7 @@ storiesOf('Components|Tiles', module)
                       <h5 className='mc-text-h5'>
                         Shonda Rhimes
                       </h5>
-                      <p className='mc-text--muted'>
+                      <p className='mc-opacity--muted'>
                         Teaches Writing
                       </p>
                     </TileCaption>
@@ -213,7 +213,7 @@ storiesOf('Components|Tiles', module)
                         <h5 className='mc-text-h5'>
                           Shonda Rhimes
                         </h5>
-                        <p className='mc-text--muted'>
+                        <p className='mc-opacity--muted'>
                           Teaches Writing
                         </p>
 
@@ -221,7 +221,7 @@ storiesOf('Components|Tiles', module)
                           <p className={`
                             mc-mt-2
                             mc-text-small
-                            mc-text--muted
+                            mc-opacity--muted
                           `}>
                             Some other stuff...
                           </p>

--- a/src/components/ToggleHandler/index.stories.js
+++ b/src/components/ToggleHandler/index.stories.js
@@ -17,7 +17,7 @@ storiesOf('utilities|ToggleHandler', module)
     <div className='container'>
       <div className='example__heading'>
         <h1 className='mc-text-h1'>ToggleHandler</h1>
-        <p className='mc-text--muted'>
+        <p className='mc-opacity--muted'>
           Simplified way of tracking a toggle state
         </p>
       </div>

--- a/src/components/VideoPlayer/index.stories.js
+++ b/src/components/VideoPlayer/index.stories.js
@@ -95,7 +95,7 @@ storiesOf('Components|VideoPlayer', module)
                           <h5 className='mc-text-h5 mc-text--uppercase'>
                             Shonda Rhimes
                           </h5>
-                          <p className='mc-text--muted'>
+                          <p className='mc-opacity--muted'>
                             Teaches Writing For Television
                           </p>
                         </TileCaption>

--- a/src/foundation/grid/index.stories.js
+++ b/src/foundation/grid/index.stories.js
@@ -199,7 +199,7 @@ storiesOf('Foundation|Grid', module)
         <div className='uncontainer'>
           <div className='container mc-mb-4'>
             <h5 className='mc-text-h5'>Contained Content</h5>
-            <p className='mc-text--muted'>
+            <p className='mc-opacity--muted'>
               Containers will keep the edge of your content lined up, as well
               as adding a barrier between the content and edge of screen.  The
               width maxes out at 1200px, and padding depends on screen size.
@@ -208,17 +208,17 @@ storiesOf('Foundation|Grid', module)
 
           <div className='container-fluid mc-mb-4'>
             <h5 className='mc-text-h5'>Fluidly Contained Content</h5>
-            <p className='mc-text--muted'>
+            <p className='mc-opacity--muted'>
               Identical to a normal container, but the width does not max out.
             </p>
           </div>
 
           <h5 className='mc-text-h5'>Uncontained Content</h5>
-          <p className='mc-text--muted'>
+          <p className='mc-opacity--muted'>
             You can use uncontainers to break any div out from
             the inside of a container.
           </p>
-          <p className='mc-text--muted'>
+          <p className='mc-opacity--muted'>
             The class pulls your content out of the wrapping container so
             your content lines up just as if it were inside a regular container!
           </p>

--- a/src/foundation/scale/index.stories.js
+++ b/src/foundation/scale/index.stories.js
@@ -37,7 +37,7 @@ class Scale extends PureComponent {
         />
 
         <DocSection title='Theory'>
-          <p className='mc-text--hinted mc-mb-2'>
+          <p className='mc-opacity--hinted mc-mb-2'>
             mc-components uses a 4px decaying step scale to provide a
             collection of values used to space and size components.
             These step values are the result of a somewhat interesting
@@ -46,7 +46,7 @@ class Scale extends PureComponent {
             that is appealing as well as programmatic.
           </p>
 
-          <p className='mc-text--hinted mc-mb-5'>
+          <p className='mc-opacity--hinted mc-mb-5'>
             Due to the decay, the computed values of each step are different
             for the three main breakpoints (LG, MD, SM). The decay does not
             apply to the smaller steps (4 and below).
@@ -68,7 +68,7 @@ class Scale extends PureComponent {
                     )}
                   </tr>
 
-                  <tr className='mc-text--muted'>
+                  <tr className='mc-opacity--muted'>
                     <th>Step</th>
 
                     {renderSteps(i =>
@@ -76,7 +76,7 @@ class Scale extends PureComponent {
                     )}
                   </tr>
 
-                  <tr className='mc-text--silenced'>
+                  <tr className='mc-opacity--silenced'>
                     <th>Func</th>
                     <th>N</th>
                     <th>2N</th>
@@ -108,7 +108,7 @@ class Scale extends PureComponent {
                     )}
                   </tr>
 
-                  <tr className='mc-text-x-small mc-text--silenced'>
+                  <tr className='mc-text-x-small mc-opacity--silenced'>
                     <th>MD</th>
 
                     {renderSteps(i =>
@@ -122,7 +122,7 @@ class Scale extends PureComponent {
                     )}
                   </tr>
 
-                  <tr className='mc-text-x-small mc-text--silenced'>
+                  <tr className='mc-text-x-small mc-opacity--silenced'>
                     <th>SM</th>
 
                     {renderSteps(i =>
@@ -169,7 +169,7 @@ class Scale extends PureComponent {
         </DocSection>
 
         <DocSection title='Usage'>
-          <p className='mc-text--hinted mc-mb-2'>
+          <p className='mc-opacity--hinted mc-mb-2'>
             There are many ways this scale is used, and that will probably
             continue to grow.  From type sizing to content spacing, the values
             genearted by this scale are littered throughout the library.
@@ -178,7 +178,7 @@ class Scale extends PureComponent {
             using the scale.
           </p>
 
-          <p className='mc-text--hinted mc-mb-8'>
+          <p className='mc-opacity--hinted mc-mb-8'>
             There is a SCSS function and mixin provided by mc-components to
             make use of the scale efficiently. Most likely you&apos;ll only
             need to employ the mixin, as it was intended to do most of the
@@ -191,7 +191,7 @@ class Scale extends PureComponent {
 }`}
           </Highlight>
 
-          <p className='mc-text--hinted mc-mb-2'>
+          <p className='mc-opacity--hinted mc-mb-2'>
             This will apply a padding with an initial value of 20px, scaling
             down to 19px on MD (tablet) screens, and 18px on SM (phone).
           </p>

--- a/src/foundation/spacing/index.stories.js
+++ b/src/foundation/spacing/index.stories.js
@@ -17,19 +17,19 @@ storiesOf('Foundation|Spacing', module)
       />
 
       <DocSection title='Theory'>
-        <p className='mc-text--hinted mc-mb-2'>
+        <p className='mc-opacity--hinted mc-mb-2'>
           mc-components uses a 4px decaying step scale to space
           and size components.  The scale is a a mix of
           linear and exponential steps, which helps acheive a
           visual progression that is appealing and programmatic.
         </p>
 
-        <p className='mc-text--hinted mc-mb-2'>
+        <p className='mc-opacity--hinted mc-mb-2'>
           The scale implementation logic and rules can be veiwed under
           the &ldquo;Introduction &gt; Scale&rdquo; section.
         </p>
 
-        <p className='mc-text--hinted'>
+        <p className='mc-opacity--hinted'>
           Due to the decay, the computed values of each step are different
           for the three main breakpoints (LG, MD, SM). The decay does not
           apply to the smaller steps (4 and below).
@@ -38,7 +38,7 @@ storiesOf('Foundation|Spacing', module)
 
 
       <DocSection title='Notation'>
-        <p className='mc-text--hinted mc-mb-2'>
+        <p className='mc-opacity--hinted mc-mb-2'>
           The helper margin and padding class is structured
           using this format:
         </p>
@@ -56,7 +56,7 @@ storiesOf('Foundation|Spacing', module)
               <th className='example__table--shrink'>
                 <span className='mc-code'>m</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced using margins
               </td>
             </tr>
@@ -65,7 +65,7 @@ storiesOf('Foundation|Spacing', module)
               <th className='example__table--shrink'>
                 <span className='mc-code'>p</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced using padding
               </td>
             </tr>
@@ -81,7 +81,7 @@ storiesOf('Foundation|Spacing', module)
               <th className='example__table--shrink'>
                 <span className='mc-code'>x</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced on x axis (left and right)
               </td>
             </tr>
@@ -90,7 +90,7 @@ storiesOf('Foundation|Spacing', module)
               <th className='example__table--shrink'>
                 <span className='mc-code'>y</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced on y-axis (top and bottom)
               </td>
             </tr>
@@ -99,7 +99,7 @@ storiesOf('Foundation|Spacing', module)
               <th className='example__table--shrink'>
                 <span className='mc-code'>t</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced only on top (margin-top)
               </td>
             </tr>
@@ -108,7 +108,7 @@ storiesOf('Foundation|Spacing', module)
               <th className='example__table--shrink'>
                 <span className='mc-code'>r</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced only on right (margin-right)
               </td>
             </tr>
@@ -117,7 +117,7 @@ storiesOf('Foundation|Spacing', module)
               <th>
                 <span className='mc-code'>b</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced only on bottom (margin-bottom)
               </td>
             </tr>
@@ -126,7 +126,7 @@ storiesOf('Foundation|Spacing', module)
               <th>
                 <span className='mc-code'>l</span>
               </th>
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Spaced only on left (margin-left)
               </td>
             </tr>
@@ -143,7 +143,7 @@ storiesOf('Foundation|Spacing', module)
                 <span className='mc-code'>#</span>
               </th>
 
-              <td className='mc-text--muted'>
+              <td className='mc-opacity--muted'>
                 Any one of the values on the mc-components scale shown
                 under &ldquo;Introduction &gt; Scale&rdquo; is valid.
               </td>
@@ -153,12 +153,12 @@ storiesOf('Foundation|Spacing', module)
       </DocSection>
 
       <DocSection title='Examples'>
-        <p className='mc-text--hinted mc-mb-5'>
+        <p className='mc-opacity--hinted mc-mb-5'>
           All examples shown use the margin option and
           a use case of scale(4) for consistency.
         </p>
 
-        <p className='mc-text--hinted mc-mb-2'>
+        <p className='mc-opacity--hinted mc-mb-2'>
           For margins with scale(4) on all sides:
         </p>
 
@@ -166,7 +166,7 @@ storiesOf('Foundation|Spacing', module)
           {'<Element className=\'mc-m-4\' />'}
         </Highlight>
 
-        <p className='mc-text--hinted mc-mb-2'>
+        <p className='mc-opacity--hinted mc-mb-2'>
           Margins with scale(4) on x-axis only:
         </p>
 
@@ -174,7 +174,7 @@ storiesOf('Foundation|Spacing', module)
           {'<Element className=\'mc-mx-4\' />'}
         </Highlight>
 
-        <p className='mc-text--hinted mc-mb-2'>
+        <p className='mc-opacity--hinted mc-mb-2'>
           Margins with scale(4) on y-axis only:
         </p>
 
@@ -182,7 +182,7 @@ storiesOf('Foundation|Spacing', module)
           {'<Element className=\'mc-my-4\' />'}
         </Highlight>
 
-        <p className='mc-text--hinted mc-mb-2'>
+        <p className='mc-opacity--hinted mc-mb-2'>
           Margins with scale(4) on top only:
         </p>
 

--- a/src/foundation/typography/modifiers.stories.js
+++ b/src/foundation/typography/modifiers.stories.js
@@ -41,34 +41,6 @@ const Modifiers = () =>
       </PropExample>
     </DocSection>
 
-    <DocSection title='Color'>
-      <div className='row'>
-        <div className='col-md-4'>
-          <PropExample name='.mc-text--hinted'>
-            <h6 className='mc-text-h5 mc-text--hinted'>
-              The quick brown fox jumped over the lazy dog.
-            </h6>
-          </PropExample>
-        </div>
-
-        <div className='col-md-4'>
-          <PropExample name='.mc-text--muted'>
-            <h6 className='mc-text-h5 mc-text--muted'>
-              The quick brown fox jumped over the lazy dog.
-            </h6>
-          </PropExample>
-        </div>
-
-        <div className='col-md-4'>
-          <PropExample name='.mc-text--silenced'>
-            <h6 className='mc-text-h5 mc-text--silenced'>
-              The quick brown fox jumped over the lazy dog.
-            </h6>
-          </PropExample>
-        </div>
-      </div>
-    </DocSection>
-
     <DocSection
       title='Alignment'
       description='Modifier classes to aid you in text alignment.'

--- a/src/foundation/typography/summary.stories.js
+++ b/src/foundation/typography/summary.stories.js
@@ -78,9 +78,9 @@ class Summary extends PureComponent {
     const modifierClass = cn({
       'mc-text--airy': modifier === MODIFIER_AIRY,
       'mc-text--uppercase': modifier === MODIFIER_UPPERCASE,
-      'mc-text--hinted': color === COLOR_HINTED,
-      'mc-text--muted': color === COLOR_MUTED,
-      'mc-text--silenced': color === COLOR_SILENCED,
+      'mc-opacity--hinted': color === COLOR_HINTED,
+      'mc-opacity--muted': color === COLOR_MUTED,
+      'mc-opacity--silenced': color === COLOR_SILENCED,
     })
 
     return (
@@ -169,7 +169,7 @@ class Summary extends PureComponent {
           <div className='mc-mb-9'>
             <div className='row'>
               <div className='col-sm-6 offset-sm-1'>
-                <h2 className='mc-text-h5 mc-text--muted mc-text--airy'>
+                <h2 className='mc-text-h5 mc-opacity--muted mc-text--airy'>
                   Lorem Ipsum
                 </h2>
 
@@ -186,13 +186,13 @@ class Summary extends PureComponent {
                 <h3 className='mc-text-h3 mc-text--uppercase mc-text--bare-link mc-mb-2'>
                   Group Workshop: From Here To Alli By Corey Wright
                 </h3>
-                <p className='mc-text--muted mc-mb-2'>
+                <p className='mc-opacity--muted mc-mb-2'>
                   Every great story is born
                   from <a className='mc-text--link'>intentions and
                   obstacles</a>. Learn how to build the &quot;drive shaft&quot;
                   that will set your script in motion.
                 </p>
-                <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-mb-3'>
+                <h6 className='mc-text-small mc-opacity--silenced mc-text--uppercase mc-mb-3'>
                   Lesson 16 // 5min 40s
                 </h6>
               </div>
@@ -201,12 +201,12 @@ class Summary extends PureComponent {
                 <h3 className='mc-text-h5 mc-text--bare-link mc-mb-2'>
                   Group Workshop: From Here To Alli By Corey Wright
                 </h3>
-                <p className='mc-text--muted mc-mb-2'>
+                <p className='mc-opacity--muted mc-mb-2'>
                   Every great story is born from intentions and obstacles.
                   Learn how to build the &quot;drive shaft&quot; that will
                   set your script in motion.
                 </p>
-                <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-mb-3'>
+                <h6 className='mc-text-small mc-opacity--silenced mc-text--uppercase mc-mb-3'>
                   Lesson 16 // 5min 40s
                 </h6>
               </div>
@@ -215,12 +215,12 @@ class Summary extends PureComponent {
                 <h3 className='mc-text-h5 mc-text--bare-link mc-mb-2'>
                   Group Workshop: From Here To Alli By Corey Wright
                 </h3>
-                <p className='mc-text--muted mc-mb-2'>
+                <p className='mc-opacity--muted mc-mb-2'>
                   Every great story is born from intentions and obstacles.
                   Learn how to build the &quot;drive shaft&quot; that will
                   set your script in motion.
                 </p>
-                <h6 className='mc-text-small mc-text--silenced mc-text--uppercase mc-mb-3'>
+                <h6 className='mc-text-small mc-opacity--silenced mc-text--uppercase mc-mb-3'>
                   Lesson 16 // 5min 40s
                 </h6>
               </div>
@@ -229,20 +229,20 @@ class Summary extends PureComponent {
             <div className='col-sm-4'>
               <div className='row mc-text--bare-link-parent'>
                 <div className='col-auto'>
-                  <h6 className='mc-text-h7 mc-text--muted'>
+                  <h6 className='mc-text-h7 mc-opacity--muted'>
                     3
                   </h6>
                 </div>
 
                 <div className='col-10'>
-                  <h6 className='mc-text-h7 mc-text--muted mc-text--uppercase mc-mb-2'>
+                  <h6 className='mc-text-h7 mc-opacity--muted mc-text--uppercase mc-mb-2'>
                     Up Next
                   </h6>
 
                   <h6 className='mc-text-h6 mc-text--bare-link mc-mb-2'>
                     Mastering Ingredients: Vegetables &amp; Herbs
                   </h6>
-                  <p className='mc-text-x-small mc-text--muted'>
+                  <p className='mc-text-x-small mc-opacity--muted'>
                     Do ugly vegetables taste better? Which are the most
                     versatile herbs? Gordon shows you how to select great
                     produce to create phenomenal dishes.
@@ -254,7 +254,7 @@ class Summary extends PureComponent {
 
               <div className='row mc-text--bare-link-parent'>
                 <div className='col-auto'>
-                  <h6 className='mc-text-h7 mc-text--muted'>
+                  <h6 className='mc-text-h7 mc-opacity--muted'>
                     4
                   </h6>
                 </div>
@@ -263,7 +263,7 @@ class Summary extends PureComponent {
                   <h6 className='mc-text-h6 mc-text--bare-link mc-mb-2'>
                     Mastering Ingredients: Vegetables &amp; Herbs
                   </h6>
-                  <p className='mc-text-x-small mc-text--muted'>
+                  <p className='mc-text-x-small mc-opacity--muted'>
                     Do ugly vegetables taste better? Which are the most
                     versatile herbs? Gordon shows you how to select great
                     produce to create phenomenal dishes.
@@ -275,7 +275,7 @@ class Summary extends PureComponent {
 
               <div className='row mc-text--bare-link-parent'>
                 <div className='col-auto'>
-                  <p className='mc-text--muted'>
+                  <p className='mc-opacity--muted'>
                     5
                   </p>
                 </div>
@@ -284,7 +284,7 @@ class Summary extends PureComponent {
                   <h6 className='mc-text-h6 mc-text--bare-link mc-mb-2'>
                     Mastering Ingredients: Vegetables &amp; Herbs
                   </h6>
-                  <p className='mc-text-x-small mc-text--muted'>
+                  <p className='mc-text-x-small mc-opacity--muted'>
                     Do ugly vegetables taste better? Which are the most
                     versatile herbs? Gordon shows you how to select great
                     produce to create phenomenal dishes.
@@ -313,7 +313,7 @@ class Summary extends PureComponent {
                         <div className='mc-card mc-background mc-background--dark'>
                           <h6 className={`
                             mc-text-h7
-                            mc-text--muted
+                            mc-opacity--muted
                             mc-text--uppercase
                             mc-mb-2
                           `}>
@@ -324,13 +324,13 @@ class Summary extends PureComponent {
                             Margaret Atwood
                           </h4>
 
-                          <p className='mc-text--muted mc-mb-2'>
+                          <p className='mc-opacity--muted mc-mb-2'>
                             Mixtape tumblr chartreuse snackwave 8-bit
                             selfies, glossier mumblecore fingerstache church-key
                             kombucha. Hot chocolate.
                           </p>
 
-                          <p className='mc-text-small mc-text--silenced'>
+                          <p className='mc-text-small mc-opacity--silenced'>
                             12 Lessons • Music
                           </p>
                         </div>

--- a/src/foundation/utilities/index.stories.js
+++ b/src/foundation/utilities/index.stories.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 
 import Display from './display.stories'
+import Opacity from './opacity.stories'
 
 storiesOf('Foundation|Utilities', module)
   .add('Display', () => <Display />)
+  .add('Opacity', () => <Opacity />)

--- a/src/foundation/utilities/opacity.stories.js
+++ b/src/foundation/utilities/opacity.stories.js
@@ -1,0 +1,48 @@
+import React from 'react'
+
+import withAddons from '../../utils/withAddons'
+import DocHeader from '../../utils/DocHeader'
+import DocSection from '../../utils/DocSection'
+import PropExample from '../../utils/PropExample'
+
+
+const Opacity = () =>
+  <div className='container'>
+    <DocHeader
+      title='Utilities - Opacity'
+      description='The opacity utility can modify the opacity of any dom element.'
+    />
+
+    <DocSection title='Color'>
+      <div className='row'>
+        <div className='col-md-4'>
+          <PropExample name='.mc-opacity--hinted'>
+            <h6 className='mc-text-h5 mc-opacity--hinted'>
+              The quick brown fox jumped over the lazy dog.
+            </h6>
+          </PropExample>
+        </div>
+
+        <div className='col-md-4'>
+          <PropExample name='.mc-opacity--muted'>
+            <h6 className='mc-text-h5 mc-opacity--muted'>
+              The quick brown fox jumped over the lazy dog.
+            </h6>
+          </PropExample>
+        </div>
+
+        <div className='col-md-4'>
+          <PropExample name='.mc-opacity--silenced'>
+            <h6 className='mc-text-h5 mc-opacity--silenced'>
+              The quick brown fox jumped over the lazy dog.
+            </h6>
+          </PropExample>
+        </div>
+      </div>
+    </DocSection>
+  </div>
+
+
+export default withAddons({
+  path: 'foundation/utilities/opacity.stories.js',
+})(() => <Opacity />)

--- a/src/foundation/variables/index.stories.js
+++ b/src/foundation/variables/index.stories.js
@@ -9,7 +9,7 @@ storiesOf('Foundation|Variables', module)
     <div className='container'>
       <div className='example__heading'>
         <h2 className='mc-text-h1'>Variables</h2>
-        <p className='mc-text--muted'>Colors, breakpoints, and mixins, oh my!</p>
+        <p className='mc-opacity--muted'>Colors, breakpoints, and mixins, oh my!</p>
       </div>
 
       <div className='example__section'>
@@ -21,7 +21,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-dark</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -29,7 +29,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-light</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -37,7 +37,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-background</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -45,7 +45,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-background-invert</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -53,7 +53,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-text</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -61,7 +61,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-text-invert</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
           </div>
@@ -73,7 +73,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-100</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -81,7 +81,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-200</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -89,7 +89,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-300</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -97,7 +97,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-400</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -105,7 +105,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-500</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -113,7 +113,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-600</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -121,7 +121,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-700</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -129,7 +129,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-gray-800</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
           </div>
@@ -141,7 +141,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-primary</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -149,7 +149,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-primary-hover</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -157,7 +157,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-primary-active</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
           </div>
@@ -169,7 +169,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-secondary</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -177,7 +177,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-secondary-hover</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -185,7 +185,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-secondary-active</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
           </div>
@@ -197,7 +197,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-tertiary</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
 
@@ -205,7 +205,7 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-tertiary-hover</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
           </div>
@@ -217,14 +217,14 @@ storiesOf('Foundation|Variables', module)
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-error</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
             <div className='example-mc-swatch example-mc-swatch--mc-color-warning mc-mb-4'>
               <span className='example-mc-swatch__color'></span>
               <div>
                 <p className='mc-text-h6 mc-text--monospace'>$mc-color-warning</p>
-                <p className='example-mc-swatch__hex mc-text-h6 mc-text--muted mc-text--monospace'></p>
+                <p className='example-mc-swatch__hex mc-text-h6 mc-opacity--muted mc-text--monospace'></p>
               </div>
             </div>
           </div>
@@ -239,31 +239,31 @@ storiesOf('Foundation|Variables', module)
             <table className='example__table'>
               <tbody>
                 <tr className='mc-example-breakpoint mc-text--monospace'>
-                  <td className='mc-text--muted'>$grid-gutter-width</td>
+                  <td className='mc-opacity--muted'>$grid-gutter-width</td>
                   <td className='mc-text--right mc-text--bold mc-gutter-value' />
                 </tr>
                 <tr className='mc-example-breakpoint mc-text--monospace'>
-                  <td className='mc-text--muted'>$grid-gutter-width-xl</td>
+                  <td className='mc-opacity--muted'>$grid-gutter-width-xl</td>
                   <td className='mc-text--right mc-text--bold mc-gutter-value--xl' />
                 </tr>
                 <tr className='mc-example-breakpoint mc-text--monospace'>
-                  <td className='mc-text--muted'>$mc-bp-xs</td>
+                  <td className='mc-opacity--muted'>$mc-bp-xs</td>
                   <td className='mc-text--right mc-text--bold mc-bp-value--xs' />
                 </tr>
                 <tr className='mc-example-breakpoint mc-text--monospace'>
-                  <td className='mc-text--muted'>$mc-bp-sm</td>
+                  <td className='mc-opacity--muted'>$mc-bp-sm</td>
                   <td className='mc-text--right mc-text--bold mc-bp-value--sm' />
                 </tr>
                 <tr className='mc-example-breakpoint mc-text--monospace'>
-                  <td className='mc-text--muted'>$mc-bp-md</td>
+                  <td className='mc-opacity--muted'>$mc-bp-md</td>
                   <td className='mc-text--right mc-text--bold mc-bp-value--md' />
                 </tr>
                 <tr className='mc-example-breakpoint mc-text--monospace'>
-                  <td className='mc-text--muted'>$mc-bp-lg</td>
+                  <td className='mc-opacity--muted'>$mc-bp-lg</td>
                   <td className='mc-text--right mc-text--bold mc-bp-value--lg' />
                 </tr>
                 <tr className='mc-example-breakpoint mc-text--monospace'>
-                  <td className='mc-text--muted'>$mc-bp-xl</td>
+                  <td className='mc-opacity--muted'>$mc-bp-xl</td>
                   <td className='mc-text--right mc-text--bold mc-bp-value--xl' />
                 </tr>
               </tbody>

--- a/src/playground/home/index.stories.js
+++ b/src/playground/home/index.stories.js
@@ -104,10 +104,10 @@ storiesOf('Playground|Pages', module)
                             <h2 className='mc-text-h1 mc-text--uppercase'>
                               {item.instructor}
                             </h2>
-                            <h3 className='mc-text-h3 mc-text--muted mc-text--airy mc-mb-4'>
+                            <h3 className='mc-text-h3 mc-opacity--muted mc-text--airy mc-mb-4'>
                               Teaches {item.teaches}
                             </h3>
-                            <p className='mc-text-intro mc-text--hinted mc-mb-8'>
+                            <p className='mc-text-intro mc-opacity--hinted mc-mb-8'>
                               Online classes taught by the world&apos;s
                               greatest minds.<br /> Learn from
                               {item.instructor} and all 35+ other
@@ -151,7 +151,7 @@ storiesOf('Playground|Pages', module)
                             <h6 className='mc-text-h6 mc-text--uppercase'>
                               {item.instructor}
                             </h6>
-                            <h6 className='mc-text-h8 mc-text--airy mc-text--muted'>
+                            <h6 className='mc-text-h8 mc-text--airy mc-opacity--muted'>
                               {item.teaches}
                             </h6>
                           </TileCaption>
@@ -174,22 +174,22 @@ storiesOf('Playground|Pages', module)
         </div>
 
         <div className='row justify-content-center'>
-          <div className='col-auto mc-text--muted mc-text--center'>
+          <div className='col-auto mc-opacity--muted mc-text--center'>
             <img height='20' src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/mc_press/today-4d4e4dfc0db7fa08e4e18e4b0ae9f8598e674c0de4f3349d9b74f02138604276.svg' />
           </div>
-          <div className='col-auto mc-text--muted mc-text--center'>
+          <div className='col-auto mc-opacity--muted mc-text--center'>
             <img height='20' src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/mc_press/nbc-e43bb6ae09ed3b16c8e6509a76ed454e7cb9289c3723288a84d4b31e34785222.svg' />
           </div>
-          <div className='col-auto mc-text--muted mc-text--center'>
+          <div className='col-auto mc-opacity--muted mc-text--center'>
             <img height='20' src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/mc_press/new_york_times-8e2107a8c7cb51f1ea6dff352bbe21ad7c414e2348b2fa88b0c506b5ddc80ed9.svg' />
           </div>
-          <div className='col-auto mc-text--muted mc-text--center'>
+          <div className='col-auto mc-opacity--muted mc-text--center'>
             <img height='20' src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/mc_press/billboard-afafead87dedb11a8a2c8684e2a9714dc4add1f508b91ea5ad06789197e6e8ee.svg' />
           </div>
-          <div className='col-auto mc-text--muted mc-text--center'>
+          <div className='col-auto mc-opacity--muted mc-text--center'>
             <img height='20' src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/mc_press/espn-2aca223117c3e92562149a240ff5dab1619562b8de78ed05cae0ce69c50afae8.svg' />
           </div>
-          <div className='col-auto mc-text--muted mc-text--center'>
+          <div className='col-auto mc-opacity--muted mc-text--center'>
             <img height='20' src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/mc_press/vanity_fair-cdfde3c2628fa297d4bba5cf9aaa5786cc0f0fb8c66a593bb5da88afe407ec99.svg' />
           </div>
         </div>
@@ -220,7 +220,7 @@ storiesOf('Playground|Pages', module)
                           <h4 className='mc-text-h4 mc-text--uppercase'>
                             Malcom Gladwell
                           </h4>
-                          <h5 className='mc-text-h5 mc-text--normal mc-text--muted'>
+                          <h5 className='mc-text-h5 mc-text--normal mc-opacity--muted'>
                             Teaches Writing
                           </h5>
                         </TileCaption>
@@ -247,7 +247,7 @@ storiesOf('Playground|Pages', module)
                       <h4 className='mc-text-h4 mc-text--uppercase'>
                         Alice Waters
                       </h4>
-                      <h5 className='mc-text-h5 mc-text--normal mc-text--muted'>
+                      <h5 className='mc-text-h5 mc-text--normal mc-opacity--muted'>
                         Teaches the Art of Home Cooking
                       </h5>
                     </TileCaption>
@@ -272,7 +272,7 @@ storiesOf('Playground|Pages', module)
                       <h4 className='mc-text-h4 mc-text--uppercase'>
                         Annie Leibovitz
                       </h4>
-                      <h5 className='mc-text-h5 mc-text--normal mc-text--muted'>
+                      <h5 className='mc-text-h5 mc-text--normal mc-opacity--muted'>
                         Teaches Photography
                       </h5>
                     </TileCaption>
@@ -302,7 +302,7 @@ storiesOf('Playground|Pages', module)
                   <h6 className='mc-text-h6 mc-text--uppercase'>
                     Annie Leibovitz
                   </h6>
-                  <h5 className='mc-text-h7 mc-text--uppercase mc-text--normal mc-text--muted'>
+                  <h5 className='mc-text-h7 mc-text--uppercase mc-text--normal mc-opacity--muted'>
                     Photography
                   </h5>
                 </div>
@@ -320,7 +320,7 @@ storiesOf('Playground|Pages', module)
                   <img src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/stars/user-al-9f00247416a322eee5fcefe147d2c9172a018cda43240ab2bdb383fa84100db7.png' />
                 </div>
                 <div className='col'>
-                  <h6 className='mc-text-h6 mc-text--muted'>
+                  <h6 className='mc-text-h6 mc-opacity--muted'>
                     Jesse L.
                   </h6>
                 </div>
@@ -338,7 +338,7 @@ storiesOf('Playground|Pages', module)
                   <h6 className='mc-text-h6 mc-text--uppercase'>
                     Gordon Ramsay
                   </h6>
-                  <h5 className='mc-text-h7 mc-text--uppercase mc-text--normal mc-text--muted'>
+                  <h5 className='mc-text-h7 mc-text--uppercase mc-text--normal mc-opacity--muted'>
                     Cooking
                   </h5>
                 </div>
@@ -356,7 +356,7 @@ storiesOf('Playground|Pages', module)
                   <img src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/stars/user-al-9f00247416a322eee5fcefe147d2c9172a018cda43240ab2bdb383fa84100db7.png' />
                 </div>
                 <div className='col'>
-                  <h6 className='mc-text-h6 mc-text--muted'>
+                  <h6 className='mc-text-h6 mc-opacity--muted'>
                     Pamela E.
                   </h6>
                 </div>
@@ -374,7 +374,7 @@ storiesOf('Playground|Pages', module)
                   <h6 className='mc-text-h6'>
                     James Patterson
                   </h6>
-                  <h5 className='mc-text-h7 mc-text--uppercase mc-text--normal mc-text--muted'>
+                  <h5 className='mc-text-h7 mc-text--uppercase mc-text--normal mc-opacity--muted'>
                     Writing
                   </h5>
                 </div>
@@ -391,7 +391,7 @@ storiesOf('Playground|Pages', module)
                   <img src='https://do6eyjibs3jse.cloudfront.net/assets/experiments/stars/user-al-9f00247416a322eee5fcefe147d2c9172a018cda43240ab2bdb383fa84100db7.png' />
                 </div>
                 <div className='col'>
-                  <h6 className='mc-text-h6 mc-text--muted'>
+                  <h6 className='mc-text-h6 mc-opacity--muted'>
                     Jean-Paul W.
                   </h6>
                 </div>
@@ -426,7 +426,7 @@ storiesOf('Playground|Pages', module)
                           <h4 className='mc-text-h4 mc-text--uppercase'>
                             Spike Lee
                           </h4>
-                          <h5 className='mc-text-h5 mc-text--normal mc-text--muted'>
+                          <h5 className='mc-text-h5 mc-text--normal mc-opacity--muted'>
                             Teaches Filmmaking
                           </h5>
                         </TileCaption>
@@ -453,7 +453,7 @@ storiesOf('Playground|Pages', module)
                       <h4 className='mc-text-h4 mc-text--uppercase'>
                         Daniel Negreanu
                       </h4>
-                      <h5 className='mc-text-h5 mc-text--normal mc-text--muted'>
+                      <h5 className='mc-text-h5 mc-text--normal mc-opacity--muted'>
                         Teaches Poker
                       </h5>
                     </TileCaption>
@@ -478,7 +478,7 @@ storiesOf('Playground|Pages', module)
                       <h4 className='mc-text-h4 mc-text--uppercase'>
                         Margaret Atwood
                       </h4>
-                      <h5 className='mc-text-h5 mc-text--normal mc-text--muted'>
+                      <h5 className='mc-text-h5 mc-text--normal mc-opacity--muted'>
                         Teaches Creative Writing
                       </h5>
                     </TileCaption>
@@ -497,14 +497,14 @@ storiesOf('Playground|Pages', module)
               <h3 className='mc-text-h3 mc-text--center mc-text-lg--left'>
                 Instructor Announcements
               </h3>
-              <p className='mc-text--center mc-text-lg--left mc-text--muted'>
+              <p className='mc-text--center mc-text-lg--left mc-opacity--muted'>
                 Learn from the world’s greatest minds.
               </p>
               <br />
 
               <div className='row small-gutters justify-content-center justify-content-lg-start'>
                 <div className='col-auto'>
-                  <ChevronLeft className='mc-icon--5 mc-icon--circled mc-text--muted' />
+                  <ChevronLeft className='mc-icon--5 mc-icon--circled mc-opacity--muted' />
                 </div>
 
                 <div className='col-auto'>
@@ -528,7 +528,7 @@ storiesOf('Playground|Pages', module)
                           <h6 className='mc-text-h6'>
                             Malcom Gladwell
                           </h6>
-                          <h6 className='mc-text-h8 mc-text--normal mc-text--muted'>
+                          <h6 className='mc-text-h8 mc-text--normal mc-opacity--muted'>
                             @Gladwell
                           </h6>
                         </div>
@@ -557,7 +557,7 @@ storiesOf('Playground|Pages', module)
                           <h6 className='mc-text-h6'>
                             Armin Van Buuren
                           </h6>
-                          <h6 className='mc-text-h8 mc-text--normal mc-text--muted'>
+                          <h6 className='mc-text-h8 mc-text--normal mc-opacity--muted'>
                             @arminvanbuuren
                           </h6>
                         </div>
@@ -653,13 +653,13 @@ storiesOf('Playground|Pages', module)
 
         <div className='row justify-content-center'>
           <div className='col-auto'>
-            <Twitter className='mc-icon--8 mc-icon--circled mc-text--muted' />
+            <Twitter className='mc-icon--8 mc-icon--circled mc-opacity--muted' />
           </div>
           <div className='col-auto'>
-            <Facebook className='mc-icon--8 mc-icon--circled mc-text--muted' />
+            <Facebook className='mc-icon--8 mc-icon--circled mc-opacity--muted' />
           </div>
           <div className='col-auto'>
-            <Instagram className='mc-icon--8 mc-icon--circled mc-text--muted' />
+            <Instagram className='mc-icon--8 mc-icon--circled mc-opacity--muted' />
           </div>
         </div>
       </div>

--- a/src/playground/lihp/index.stories.js
+++ b/src/playground/lihp/index.stories.js
@@ -229,7 +229,7 @@ storiesOf('Playground|Pages', module)
                             <h6 className={`
                               mc-text-h7
                               mc-text--uppercase
-                              mc-text--muted
+                              mc-opacity--muted
                               mc-mb-2
                             `}>
                               {item.instructor}
@@ -242,7 +242,7 @@ storiesOf('Playground|Pages', module)
                               <p className={`
                                 mc-mt-2
                                 mc-text-small
-                                mc-text--muted
+                                mc-opacity--muted
                               `}>
                                 {`${item.extract}`}
                               </p>
@@ -306,7 +306,7 @@ storiesOf('Playground|Pages', module)
                             <h6 className='mc-text-h6 mc-text--airy mc-mb-2'>
                               {item.instructor}
                             </h6>
-                            <p className='mc-text-small mc-text--hinted'>
+                            <p className='mc-text-small mc-opacity--hinted'>
                               {item.course}
                             </p>
                           </TileCaption>
@@ -334,7 +334,7 @@ storiesOf('Playground|Pages', module)
                                   <h6 className='mc-text-h6 mc-text--airy mc-mb-2'>
                                     {item.instructor}
                                   </h6>
-                                  <p className='mc-text-small mc-text--hinted mc-mb-2'>
+                                  <p className='mc-text-small mc-opacity--hinted mc-mb-2'>
                                     {item.course}
                                   </p>
                                   <p className='mc-text-x-small mc-mb-8'>
@@ -386,7 +386,7 @@ storiesOf('Playground|Pages', module)
                 `}>
                   Natalie Portman
                 </h2>
-                <p className='mc-mb-6 mc-text--hinted'>
+                <p className='mc-mb-6 mc-opacity--hinted'>
                   Teaches Cooking Techniques II: Meats, Stocks, And Sauces
                 </p>
                 <Button>
@@ -431,7 +431,7 @@ storiesOf('Playground|Pages', module)
                       <h6 className={`
                         mc-text-h8
                         mc-text--uppercase
-                        mc-text--hinted
+                        mc-opacity--hinted
                       `}>
                         {item.playlist}
                       </h6>
@@ -447,7 +447,7 @@ storiesOf('Playground|Pages', module)
                     <p className={`
                       mc-mt-2
                       mc-text-small
-                      mc-text--hinted
+                      mc-opacity--hinted
                       mc-text--3-lines
                     `}>
                       {`${item.extract}`}

--- a/src/styles/helpers/_helpers.scss
+++ b/src/styles/helpers/_helpers.scss
@@ -1,5 +1,6 @@
 @import "images";
 @import "grid";
+@import "opacity";
 @import "spacing-margin";
 @import "spacing-padding";
 @import "corners";

--- a/src/styles/helpers/_opacity.scss
+++ b/src/styles/helpers/_opacity.scss
@@ -1,0 +1,6 @@
+// stylelint-disable declaration-no-important
+.mc-opacity {
+  &--hinted { opacity: 0.8 !important; }
+  &--muted { opacity: 0.5 !important; }
+  &--silenced { opacity: 0.3 !important; }
+}

--- a/src/styles/typography/_modifiers.scss
+++ b/src/styles/typography/_modifiers.scss
@@ -13,9 +13,6 @@
   &--italic { font-style: italic !important; }
   &--normal { font-weight: 400 !important; }
   &--light { font-weight: 300 !important; }
-  &--hinted { opacity: 0.8 !important; }
-  &--muted { opacity: 0.5 !important; }
-  &--silenced { opacity: 0.3 !important; }
 
   // Treatments
   &--airy {

--- a/src/utils/DocHeader.js
+++ b/src/utils/DocHeader.js
@@ -38,7 +38,7 @@ export default class DocHeader extends PureComponent {
               }
             </h1>
 
-            <p className='mc-text-large mc-text--muted'>
+            <p className='mc-text-large mc-opacity--muted'>
               {description}
             </p>
           </div>

--- a/src/utils/PropExample.js
+++ b/src/utils/PropExample.js
@@ -34,7 +34,7 @@ export default class Definition extends PureComponent {
         }
 
         {description &&
-          <p className='example__definition-description mc-text--muted'>
+          <p className='example__definition-description mc-opacity--muted'>
             {description}
           </p>
         }


### PR DESCRIPTION
## Overview
Updates the text modifier opacity helpers to be named more generically since we're using it in many different use cases now.

## Risks
This is a *breaking change* - we will need to update all the implementations in the main masterclass repo before this can be merged in.

This will need to be find / replaced in the main repo:

from `.mc-text--hinted` to `.mc-opacity--hinted`
from `.mc-text--muted` to `.mc-opacity--muted`
from `.mc-text--silenced` to `.mc-opacity--silenced`

## Changes
Changes naming of `mc-text--subtle` to `mc-opacity--subtle` (and same for hinted and silenced).

## Issue
https://github.com/yankaindustries/mc-components/issues/516
