### PR TITLE
Fixing screens when the render runs after the player initializes

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -131,6 +131,9 @@ export default class VideoPlayer extends PureComponent {
   handlePlayerReady = () => {
     const { onPlayerReady } = this.props
 
+    // eslint-disable-next-line
+    this.setState({ videoRoot: this.video.el_ })
+
     this.video.on('play', this.handlePlay)
     this.video.on('pause', this.handlePause)
     this.video.on('ended', this.handleEnd)
@@ -383,18 +386,21 @@ export default class VideoPlayer extends PureComponent {
 
   render () {
     const {
-      endscreenComponent,
       beforescreenComponent,
       pausescreenComponent,
-      videoId,
+      endscreenComponent,
+
+      accountId,
       playerId,
+      videoId,
+
       hasControls,
       isMuted,
-      accountId,
     } = this.props
 
     const {
       screen,
+      videoRoot,
     } = this.state
 
     const isScreenOpen = screen !== SCREEN_NONE
@@ -409,9 +415,6 @@ export default class VideoPlayer extends PureComponent {
       'bc-player__video--default',
       'video-js',
     )
-
-    // eslint-disable-next-line
-    const videoRoot = this.video ? this.video.el_ : undefined
 
     return (
       <div

--- a/src/components/VideoPlayer/index.stories.js
+++ b/src/components/VideoPlayer/index.stories.js
@@ -188,7 +188,6 @@ storiesOf('Components|VideoPlayer', module)
               description='Renders a component when the video is done.'
             >
               <VideoPlayer
-                progress={11}
                 endscreenComponent={
                   ({ onReplay }) =>
                     <Background color='dim' fit='container'>


### PR DESCRIPTION
## Overview
Video screens seemed to be rendered while the video player was still initializing.  This caused the before screen to return null (as it won't render unless it is passed the video root element.  Because nothing is re-triggering a re-render, the beforescreenElement would never properly render.  Switching the root element to be stored in state causes the render to run again once it is changed.

## Risks
Low, this doesn't change the implementation side of things, just the mechanism that causes the render to trigger (state change) more reliably

## Changes
n/a

## Issue
n/a
