### PR TITLE
VideoPlayer - Crop video for non-16x9 player sizes.

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -15,6 +15,10 @@ const SCREEN_END = 'SCREEN_END'
 const SCREEN_PAUSE = 'SCREEN_PAUSE'
 const SCREEN_NONE = 'SCREEN_NONE'
 
+const FILL_WIDTH = 'width'
+const FILL_HEIGHT = 'height'
+const FILL_NONE = null
+
 const CC_HIDDEN = 'hidden'
 
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
@@ -63,6 +67,7 @@ export default class VideoPlayer extends PureComponent {
 
   state = {
     screen: SCREEN_NONE,
+    fill: FILL_NONE,
   }
 
   constructor (props) {
@@ -146,6 +151,7 @@ export default class VideoPlayer extends PureComponent {
     }
 
     this.startSecondsTimer()
+    this.calculateFill()
   }
 
   handlePlay = () => {
@@ -384,6 +390,17 @@ export default class VideoPlayer extends PureComponent {
     }
   }
 
+  calculateFill = () => {
+    const container = this.playerRef.current
+
+    const videoRatio = 16 / 9
+    const playerRatio = container.offsetWidth / container.offsetHeight
+
+    const fill = playerRatio > videoRatio ? FILL_WIDTH : FILL_HEIGHT
+
+    this.setState({ fill })
+  }
+
   render () {
     const {
       beforescreenComponent,
@@ -401,6 +418,7 @@ export default class VideoPlayer extends PureComponent {
     const {
       screen,
       videoRoot,
+      fill,
     } = this.state
 
     const isScreenOpen = screen !== SCREEN_NONE
@@ -410,11 +428,12 @@ export default class VideoPlayer extends PureComponent {
       'bc-player--screen-open': isScreenOpen,
     })
 
-    const playerClasses = cn(
-      'bc-player__video',
-      'bc-player__video--default',
-      'video-js',
-    )
+    const playerClasses = cn({
+      'bc-player__video': true,
+      'bc-player__video--default': true,
+      'video-js': true,
+      [`vjs-fill-${fill}`]: !!fill,
+    })
 
     return (
       <div

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -107,15 +107,18 @@
   }
 
   .bc-player {
+    width: 100%;
     height: 100%;
 
     .vjs-tech {
       position: absolute;
       left: 50%;
-      top: 0;
+      top: 50%;
       width: auto;
+      height: auto;
+      min-width: 100%;
       min-height: 100%;
-      transform: translateX(-50%);
+      transform: translate(-50%, -50%);
     }
   }
 }

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -109,17 +109,6 @@
   .bc-player {
     width: 100%;
     height: 100%;
-
-    .vjs-tech {
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      width: auto;
-      height: auto;
-      min-width: 100%;
-      min-height: 100%;
-      transform: translate(-50%, -50%);
-    }
   }
 }
 

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -107,11 +107,16 @@
   }
 
   .bc-player {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    width: 100%;
-    transform: translate(-50%, -50%);
+    height: 100%;
+
+    .vjs-tech {
+      position: absolute;
+      left: 50%;
+      top: 0;
+      width: auto;
+      min-height: 100%;
+      transform: translateX(-50%);
+    }
   }
 }
 

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -318,8 +318,12 @@ $mc-video-progress-height: 0.8rem !default;
   .vjs-control-bar {
     background: rgba($mc-color-dark, 0.4);
   }
-}
 
+  // POSTER
+  .vjs-poster {
+    background-size: cover;
+  }
+}
 
 // HIDE
 .vjs-contextmenu-ui-menu {

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -188,8 +188,33 @@ $mc-video-progress-height: 0.8rem !default;
 }
 
 
-// MENUS
 .video-js {
+  // VIDEO
+  .vjs-tech {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    height: 100%;
+
+    &.vjs-fill-width {
+      width: 100%;
+      height: auto;
+    }
+
+    &.vjs-fill-height {
+      height: 100%;
+      width: auto;
+    }
+  }
+
+  // POSTER
+  .vjs-poster {
+    background-size: cover;
+  }
+
+  // MENUS
   &.vjs-quality-menu .vjs-quality-menu-button-4K-flag:after,
   &.vjs-quality-menu .vjs-quality-menu-button-HD-flag:after {
     font-size: 0.6em;
@@ -317,11 +342,6 @@ $mc-video-progress-height: 0.8rem !default;
 
   .vjs-control-bar {
     background: rgba($mc-color-dark, 0.4);
-  }
-
-  // POSTER
-  .vjs-poster {
-    background-size: cover;
   }
 }
 


### PR DESCRIPTION
## Overview
TileVideo can be in Tiles that are not 16x9, but they show letterboxing.  This is not ideal, so I've update the VideoPlayer to support containers/players that are any aspect ratio.

## Risks
Medium - Will need to test live video instances to make sure no unintended consequences occur, and double check 2x3 TileVideo instances.

## Changes
<img width="299" alt="Screen Shot 2019-08-05 at 11 56 34 AM" src="https://user-images.githubusercontent.com/249444/62488027-223ea480-b778-11e9-92db-f502b55e17b9.png">

<img width="538" alt="Screen Shot 2019-08-05 at 11 56 48 AM" src="https://user-images.githubusercontent.com/249444/62488026-2074e100-b778-11e9-82a8-85911b208c66.png">

## Issue
<Does this PR fix an existing issue? If so, link to it here>
