### PR TITLE
Updating PR template to indicate whether prs are breaking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,6 @@
 
 ## Issue
 <Does this PR fix an existing issue? If so, link to it here>
+
+## Breaking change?
+<Is this a breaking change, or is it backwards compatible? | *BREAKING* / Backwards Compatible>


### PR DESCRIPTION
While versioning mc-components, I realized it'd be much easier to notice if a user adds a breaking change by specifying (instead of messaging each contributor). In the future, might be helpful to add a label instead maybe? But for now this should be good.