### PR TITLE
adding function as valid child proptype

### DIFF
--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types'
 
 
 export const PROP_TYPE_CHILDREN = PropTypes.oneOfType([
+  PropTypes.func,
   PropTypes.node,
-  PropTypes.arrayOf(PropTypes.node),
   PropTypes.arrayOf(PropTypes.func),
+  PropTypes.arrayOf(PropTypes.node),
 ])


### PR DESCRIPTION
## Overview
for some reason i left out a single function as being a valid child type, but it is

## Risks
none, proptypes only throw warnings in dev