### PR TITLE
Making TooltipToggle the most versatile

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "react/forbid-prop-types": 0,
     "react/jsx-handler-names": 0,
     "react/jsx-wrap-multilines": 0,
+    "react/no-find-dom-node": 0,
     "react/require-default-props": 0,
   },
   "globals": {

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import { findDOMNode } from 'react-dom'
 import PropTypes from 'prop-types'
 import Popper from 'popper.js'
 
@@ -74,12 +75,10 @@ export default class Dropdown extends PureComponent {
 
   renderDropdown = () => {
     const { placement } = this.props
-    const toggle = this.toggleRef.current.element
-      ? this.toggleRef.current.element.current
-      : this.toggleRef.current
+
 
     this.tooltip = new Popper(
-      toggle,
+      findDOMNode(this.toggleRef.current),
       this.dropdownRef.current,
       {
         placement,

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react'
+import { findDOMNode } from 'react-dom'
 import PropTypes from 'prop-types'
 import Popper from 'popper.js'
 
@@ -60,12 +61,9 @@ export default class Tooltip extends PureComponent {
 
   renderTooltip = () => {
     const { placement } = this.props
-    const toggle = this.toggleRef.current.element
-      ? this.toggleRef.current.element.current
-      : this.toggleRef.current
 
     this.tooltip = new Popper(
-      toggle,
+      findDOMNode(this.toggleRef.current),
       this.tooltipRef.current,
       {
         placement,


### PR DESCRIPTION
## Overview
Tooltip and Dropdown cannot rely on any implementation of their children, so we are using ReactDOM to find the nearest DOM element to use for relative spacing.

## Risks
Low - not used in a lot of cases, but this is reverse compatible.
