### PR TITLE
Remove legacy button support

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -31,17 +31,14 @@ export default class Button extends PureComponent {
       'tertiary',
       'twitter',
     ]),
-    link: PropTypes.bool, // DEPRECATED
     loading: PropTypes.bool,
     onClick: PropTypes.func,
     rounded: PropTypes.bool,
-    secondary: PropTypes.bool, // DEPRECATED
     size: PropTypes.oneOf([
       'small',
       'medium',
     ]),
     symmetrical: PropTypes.bool,
-    tertiary: PropTypes.bool, // DEPRECATED
   }
 
   static defaultProps = {


### PR DESCRIPTION
## Overview
We no longer support the button type props directly on the button, they're now "`kind`s" instead.  We kept them around to make sure we wouldn't break anything in the main mc repo, but this removal means we'll need to go back through the main mc repo to make sure we don't have any regressions.

## Risks
Low - we haven't supported this officially in a while

## Changes
Removes the prop types on the buttons, they _must_ be specified as `kind` now.

## Issue
https://github.com/yankaindustries/mc-components/issues/361

## Breaking change?
Not backwards compatible...will need to insure all `<Button>` implementations are using the correct syntax (already did a scan and only found one use case, which will be updated)