### PR TITLE
Update icons to actually use the mc-icon class

### DIFF
--- a/src/components/Icons/index.js
+++ b/src/components/Icons/index.js
@@ -7,7 +7,7 @@ const Icon = ({ kind, ...props }) => {
   const Component = ICONS[kind]
 
   return (
-    <Component {...props} />
+    <Component className='mc-icon' {...props} />
   )
 }
 

--- a/src/styles/components/_icons.scss
+++ b/src/styles/components/_icons.scss
@@ -3,9 +3,8 @@ svg {
 }
 
 .mc-icon {
-  fill: currentColor;
-  width: 16px;
-  height: 16px;
+  width: 2em;
+  height: 2em;
 
   @for $i from 1 through 16 {
     &--#{$i} {


### PR DESCRIPTION
## Overview
First step for issue #532 - need to make sure we use the `mc-icon` class before documenting it for others to use.

## Risks
None, should have no perceptible changes

## Changes
Syntax updating

## Issue
https://github.com/yankaindustries/mc-components/issues/532

## Breaking change?
Backwards compatible 