### PR TITLE
Fixing alignment issues with video player

### DIFF
--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -21,7 +21,9 @@ $mc-video-progress-height: 0.8rem !default;
     top: 50%;
     width: 100%;
     height: 100%;
-    transform: translate(-50%, -50%) scale(1.01);
+    transform: translate(-50%, -50%);
+    // Allow overflow to fix "off by one" pixel calculation
+    overflow: visible;
 
     &.vjs-fill-width {
       width: 100%;
@@ -37,12 +39,15 @@ $mc-video-progress-height: 0.8rem !default;
   &__screen {
     position: absolute;
     z-index: 1;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    top: 50%;
+    left: 50%;
     opacity: 0;
     pointer-events: none;
+    width: 100%;
+    height: 100%;
+    // Needs scale to force overflow and "round up" pixel calculation
+    // when landing on a half-pixel.
+    transform: translate(-50%, -50%) scale(1.01);
     transition: 700ms ease-out;
 
     &--is-open {


### PR DESCRIPTION
## Overview
There was an annoying issue where the control bar of the videoplayer was not lining up where your cursor was hovering. This was due to a previous bugfix for an issue where the video player wasn't occupying the full width / height of the parent container, so we had applied a `scale(1.01)` modifier with re-centering code.  Unfortunately this introduced the bug that was reported.

We've resolve the bug by adding a series of overflows / scaling to adjust correctly without affecting playhead positioning (we think).


## Risks
Low - should be a patch, but always a risk of unintended consequences.

## Changes
Fixes playhead weirdness on hover (doesn't line up correctly with where your cursor is)

## Issue
https://github.com/yankaindustries/mc-components/issues/564

## Breaking change?
Backwards compatible