### PR TITLE
Adding inline rendered font size

### DIFF
--- a/src/foundation/typography/sizes.stories.js
+++ b/src/foundation/typography/sizes.stories.js
@@ -1,94 +1,126 @@
-import React from 'react'
+import React, { PureComponent } from 'react'
 
 import withAddons from '../../utils/withAddons'
 import DocHeader from '../../utils/DocHeader'
 import PropExample from '../../utils/PropExample'
 
+class CalcSize extends PureComponent {
+  divRef = React.createRef()
 
-const Sizes = () =>
-  <div className='container'>
-    <DocHeader
-      title='Typography - Sizes'
-      description='Available heading and body size options.'
-    />
+  state = {}
 
-    <PropExample name='.mc-text-h1'>
-      <h1 className='mc-text-h1'>
-        Gordon Ramsay
-      </h1>
-    </PropExample>
+  updateSizes = () => {
+    this.setState({
+      fontSize: window.getComputedStyle(this.divRef.current).fontSize,
+    })
+  }
 
-    <PropExample name='.mc-text-h2'>
-      <h2 className='mc-text-h2'>
-        All-Access Pass
-      </h2>
-    </PropExample>
+  componentDidMount () {
+    this.updateSizes()
+    window.addEventListener('resize', this.updateSizes)
+  }
 
-    <PropExample name='.mc-text-h3'>
-      <h3 className='mc-text-h3'>
-        Now Available
-      </h3>
-    </PropExample>
+  render () {
+    return (
+      <span className='mc-code mc-opacity--muted' ref={this.divRef}>
+        {this.state.fontSize}
+      </span>
+    )
+  }
+}
 
-    <PropExample name='.mc-text-h4'>
-      <h4 className='mc-text-h4'>
-        Diane Von Furstenburg
-      </h4>
-    </PropExample>
+class Sizes extends PureComponent {
+  render () {
+    return (
+      <div className='container'>
+        <DocHeader
+          title='Typography - Sizes'
+          description='Available heading and body size options.'
+        />
 
-    <PropExample name='.mc-text-h5'>
-      <h5 className='mc-text-h5'>
-        Teaches Fashion
-      </h5>
-    </PropExample>
+        <PropExample name='.mc-text-h1'>
+          <h1 className='mc-text-h1'>
+            Gordon Ramsay <CalcSize />
+          </h1>
+        </PropExample>
 
-    <PropExample name='.mc-text-h6'>
-      <h6 className='mc-text-h6'>
-        Account Settings
-      </h6>
-    </PropExample>
+        <PropExample name='.mc-text-h2'>
+          <h2 className='mc-text-h2'>
+            All-Access Pass <CalcSize />
+          </h2>
+        </PropExample>
 
-    <PropExample name='.mc-text-h7'>
-      <h6 className='mc-text-h7'>
-        Account Settings
-      </h6>
-    </PropExample>
+        <PropExample name='.mc-text-h3'>
+          <h3 className='mc-text-h3'>
+            Now Available <CalcSize />
+          </h3>
+        </PropExample>
 
-    <PropExample name='.mc-text-h8'>
-      <h6 className='mc-text-h8'>
-        Account Settings
-      </h6>
-    </PropExample>
+        <PropExample name='.mc-text-h4'>
+          <h4 className='mc-text-h4'>
+            Diane Von Furstenburg <CalcSize />
+          </h4>
+        </PropExample>
 
-    <PropExample name='.mc-text-large'>
-      <p className='mc-text-large'>
-        Online classes taught by the world&#39;s greatest minds.<br />
-        Now get unlimited access to all classes.
-      </p>
-    </PropExample>
+        <PropExample name='.mc-text-h5'>
+          <h5 className='mc-text-h5'>
+            Teaches Fashion <CalcSize />
+          </h5>
+        </PropExample>
 
-    <PropExample name='body'>
-      <p>
-        Online classes taught by the world&#39;s greatest minds.<br />
-        Now get unlimited access to all classes.
-      </p>
-    </PropExample>
+        <PropExample name='.mc-text-h6'>
+          <h6 className='mc-text-h6'>
+            Account Settings <CalcSize />
+          </h6>
+        </PropExample>
 
-    <PropExample name='.mc-text-small'>
-      <p className='mc-text-small'>
-        Online classes taught by the world&#39;s greatest minds.<br />
-        Now get unlimited access to all classes.
-      </p>
-    </PropExample>
+        <PropExample name='.mc-text-h7'>
+          <h6 className='mc-text-h7'>
+            Account Settings <CalcSize />
+          </h6>
+        </PropExample>
 
-    <PropExample name='.mc-text-x-small'>
-      <p className='mc-text-x-small'>
-        Online classes taught by the world&#39;s greatest minds.<br />
-        Now get unlimited access to all classes.
-      </p>
-    </PropExample>
-  </div>
+        <PropExample name='.mc-text-h8'>
+          <h6 className='mc-text-h8'>
+            Account Settings <CalcSize />
+          </h6>
+        </PropExample>
 
+        <PropExample name='.mc-text-large'>
+          <p className='mc-text-large'>
+            Online classes taught by the world&#39;s greatest minds.<br />
+            Now get unlimited access to all classes.
+            <CalcSize />
+          </p>
+        </PropExample>
+
+        <PropExample name='body'>
+          <p>
+            Online classes taught by the world&#39;s greatest minds.<br />
+            Now get unlimited access to all classes.
+            <CalcSize />
+          </p>
+        </PropExample>
+
+        <PropExample name='.mc-text-small'>
+          <p className='mc-text-small'>
+            Online classes taught by the world&#39;s greatest minds.<br />
+            Now get unlimited access to all classes.
+            <CalcSize />
+          </p>
+        </PropExample>
+
+        <PropExample name='.mc-text-x-small'>
+          <p className='mc-text-x-small'>
+            Online classes taught by the world&#39;s greatest minds.<br />
+            Now get unlimited access to all classes.
+            <CalcSize />
+          </p>
+        </PropExample>
+      </div>
+    )
+  }
+}
 
 export default withAddons({
   path: 'foundation/typography/sizes.stories.js',


### PR DESCRIPTION
## Overview
I wanted to be able to show the rendered font size for each of the type values.  Sometimes you have a size and need to know which class you should use. This should make it easier to work with :D

## Risks
None, documentation change only

## Changes
The type page will now show the calculated pixel value of the type next to each item.
![image](https://user-images.githubusercontent.com/505670/64654445-20eb4200-d3de-11e9-8d42-346491eed831.png)

## Issue
N/A

## Breaking change?
Backwards compatible