### PR TITLE
DS-146 modal scroll to top

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -51,10 +51,17 @@ export default class Modal extends PureComponent {
   componentDidUpdate (prevProps) {
     const { show } = this.props
 
+    // a little hackery here to prevent scrolling/reset
+
     if (!prevProps.show && show) {
+      const scrollOffset = window.scrollY
+      document.body.style.top = -scrollOffset + 'px'
       document.body.classList.add('mc-modal__body--open')
     } else if (prevProps.show && !show) {
+      const scrollOffset = -parseInt(document.body.style.top)
       document.body.classList.remove('mc-modal__body--open')
+      document.body.style.top = undefined
+      window.scrollTo(0, scrollOffset)
     }
   }
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -55,10 +55,10 @@ export default class Modal extends PureComponent {
 
     if (!prevProps.show && show) {
       const scrollOffset = window.scrollY
-      document.body.style.top = -scrollOffset + 'px'
+      document.body.style.top = `-${scrollOffset}px`
       document.body.classList.add('mc-modal__body--open')
     } else if (prevProps.show && !show) {
-      const scrollOffset = -parseInt(document.body.style.top)
+      const scrollOffset = -parseInt(document.body.style.top, 10)
       document.body.classList.remove('mc-modal__body--open')
       document.body.style.top = undefined
       window.scrollTo(0, scrollOffset)


### PR DESCRIPTION
## Overview
fixed modal underlying body positioning so that the scroll offset doesn't get reset

## Risks
None

## Changes
currently if you're scrolled down on the homepage (logged out state) and click login, the homepage gets scrolled to the top:
![image](https://user-images.githubusercontent.com/56046844/66091826-2a2f8080-e53e-11e9-9497-edb552f8cad3.png)

## Issue
https://masterclass-dev.atlassian.net/browse/DS-146

## Breaking change?
backwards compatible