### PR TITLE
Roll back storybook deployer because it wont compile styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@storybook/addons": "^5.1.11",
     "@storybook/preset-scss": "^1.0.2",
     "@storybook/react": "^5.1.11",
-    "@storybook/storybook-deployer": "^2.8.1",
+    "@storybook/storybook-deployer": "^2.3.0",
     "@storybook/theming": "^5.2.0",
     "@svgr/cli": "^4.3.2",
     "@svgr/webpack": "^4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,7 +1528,7 @@
     memoizerific "^1.11.3"
     qs "^6.6.0"
 
-"@storybook/storybook-deployer@^2.8.1":
+"@storybook/storybook-deployer@^2.3.0":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.1.tgz#18018114d58d0c1e584d06b68e57900804469e51"
   integrity sha512-tXgD7vpX2nRGpMZr4hzZ3J34Xt3h5sbk3HjnNrBM3bMMWYf5/pMfTtlpIzyzA+ljoI77ZjuFOWZfgPaUTxHeJw==


### PR DESCRIPTION
## Overview
Storybook deployer was no longer compiling styles when deployed (it would only compile locally). @a-axton and I weren't able to figure out what exactly changed between versions so rolling back the deployer to the working version to get this working again.

## Risks
None

## Changes
N/A

## Issue
N/A

## Breaking change?
N/A
