### PR TITLE
Fixing incorrect TileImage prop

### DIFF
--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -75,7 +75,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    background-repeat: cover;
+    background-repeat: no-repeat;
     background-size: cover;
     background-position: center;
   }


### PR DESCRIPTION
## Overview
Noticed we had an incorrect value for the background-repeat property on `TileImage`s. Quick and easy fix!

## Risks
None - previous property wasn't doing anything.

## Changes
Fixed background-repeat to be correct value

## Issue
N/A

## Breaking change?
Backwards Compatible 