### PR TITLE
VideoPlayer - fix unmounting bug

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -111,6 +111,7 @@ export default class VideoPlayer extends PureComponent {
     this.video.off('seeking')
     this.video.off('fullscreenchange')
     this.video.off('loadmetadata')
+    this.video.dispose()
   }
 
   setupScript = () => {


### PR DESCRIPTION
## Overview
The VideoPlayer, if mounted and then unmounted before the video was ready, would continue to run (due to the video instance not being completely "disposed" of).

## Risks
None

## Issue
https://github.com/yankaindustries/mc-components/issues/585

## Breaking change?
Backwards Compatible
