### PR TITLE
Fixing conflicts Carousel style conflicts

### DIFF
--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -221,12 +221,10 @@ export default class Carousel extends PureComponent {
               </Slider>
             </div>
 
-            {controls &&
-              <div
-                className='mc-carousel__arrow-container'
-                ref={this.arrowContainerRef}
-              />
-            }
+            <div
+              className='mc-carousel__arrow-container'
+              ref={this.arrowContainerRef}
+            />
           </div>
         </div>
         <div className='mc-carousel__forced-spacing' />

--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -90,6 +90,7 @@ export default class Carousel extends PureComponent {
     scrollCount: 1,
     showCount: 3,
     transition: TRANSITION_SLIDE,
+    variableWidth: false,
   }
 
   arrowContainerRef = React.createRef()
@@ -151,8 +152,7 @@ export default class Carousel extends PureComponent {
       ...restProps
     } = this.props
 
-    const classes = cn({
-      [className]: className,
+    const containerClasses = cn({
       'mc-carousel': true,
       'mc-carousel--centered': centered,
       'mc-carousel--highlight-active': highlightOnActive,
@@ -160,6 +160,11 @@ export default class Carousel extends PureComponent {
       'mc-carousel--overflow': overflow,
       'mc-carousel--peek': peek,
       'mc-carousel--variable-width': variableWidth,
+    })
+
+    const carouselClasses = cn({
+      [className]: className,
+      'mc-carousel__slider': true,
     })
 
     const arrows = controls
@@ -189,14 +194,14 @@ export default class Carousel extends PureComponent {
       }
 
     return (
-      <div className={classes}>
+      <div className={containerClasses}>
         <div className='mc-carousel__forced-spacing' />
         <div className='mc-carousel__container'>
           <div className='mc-carousel__inner-container'>
             <div className='mc-carousel__slider-container'>
               <Slider
                 autoplay={autoPlay}
-                className='mc-carousel__slider'
+                className={carouselClasses}
                 centerMode={centered}
                 centerPadding={0}
                 fade={transition === TRANSITION_FADE}

--- a/src/styles/components/carousel/_modifiers.scss
+++ b/src/styles/components/carousel/_modifiers.scss
@@ -8,14 +8,14 @@
 
   &--peek {
     .mc-carousel__slider-container {
-      width: 75%;
+      padding-right: 25%;
 
       @media only screen and (min-width: $mc-bp-md) {
-        width: 80%;
+        padding-right: 20%;
       }
 
       @media only screen and (min-width: $mc-bp-lg) {
-        width: 85%;
+        padding-right: 15%;
       }
 
       &:after {
@@ -39,7 +39,9 @@
 
   &--peek,
   &--variable-width {
-    overflow: hidden;
+    .mc-carousel__slider-container {
+      overflow: hidden;
+    }
 
     .slick-slide {
       opacity: 1;


### PR DESCRIPTION
## Overview
Carousel `controls` were getting cut off when combined with `variableWidth` and/or `peek` due to the styles being tested in isolation.  Styles have been updated to work together.

Additionally, the `className` being passed to the parent container in some cases (cases where there aren't enough tiles to fill the width) had potential to cause a flexbox issue.  This is now fixed by moving the passed `className` inside of the container styles.

## Risks
None

## Breaking change?
Backwards Compatible
