### PR TITLE
fixing borked dropdown content overflow

### DIFF
--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -51,6 +51,7 @@
     display: flex;
     flex: 1;
     flex-direction: column;
+    overflow: auto;
 
     &-container {
       position: relative;
@@ -58,7 +59,6 @@
       flex-direction: column;
       width: 100vw;
       max-height: 100vh;
-      overflow: auto;
       z-index: $mc-zindex-dropdown;
 
       background: var(--mc-theme-dropdown-bg);


### PR DESCRIPTION
## Overview
just a tiny fix for the dropdown content overflow scrolling

## Risks
Low

## Changes
currently header and footer aren't sticky in 'actions' dropdown
![image](https://user-images.githubusercontent.com/56046844/67252290-24cfa280-f427-11e9-9a42-ae427f3c5e15.png)

this change just fixes that:
![image](https://user-images.githubusercontent.com/56046844/67252314-3d3fbd00-f427-11e9-8fbf-3af5e037c791.png)


## Issue
no issue currently being tracked

## Breaking change?
backwards compatible
