### PR TITLE
[WIP] flipping containers to be without gutters by default

### DIFF
--- a/src/foundation/grid/index.stories.js
+++ b/src/foundation/grid/index.stories.js
@@ -11,7 +11,7 @@ storiesOf('Foundation|Grid', module)
   .add('Summary', withAddons({
     path: 'foundation/grid/index.stories.js',
   })(() => (
-    <div className='container'>
+    <div className='container gutters'>
       <DocHeader
         title='Grid'
         description='A demo of the grid system in mc-components.'
@@ -162,8 +162,8 @@ storiesOf('Foundation|Grid', module)
         </div>
       </PropExample>
 
-      <PropExample name='.row.no-gutters'>
-        <div className='row no-gutters'>
+      <PropExample name='.row.gutters'>
+        <div className='row gutters'>
           <div className='col-6'>
             <Placeholder className='example-grid-block'>.col-6</Placeholder>
           </div>
@@ -220,8 +220,8 @@ storiesOf('Foundation|Grid', module)
         </div>
       </PropExample>
 
-      <PropExample name='.row.no-gutters-vertical'>
-        <div className='row no-gutters-vertical'>
+      <PropExample name='.row.gutters-horizontal'>
+        <div className='row gutters-horizontal'>
           <div className='col-6'>
             <Placeholder className='example-grid-block'>.col-6</Placeholder>
           </div>
@@ -230,7 +230,7 @@ storiesOf('Foundation|Grid', module)
           </div>
         </div>
 
-        <div className='row no-gutters-vertical'>
+        <div className='row gutters-horizontal'>
           <div className='col-sm-12 col-md-4'>
             <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
           </div>
@@ -242,7 +242,127 @@ storiesOf('Foundation|Grid', module)
           </div>
         </div>
 
-        <div className='row no-gutters-vertical'>
+        <div className='row gutters-horizontal'>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+        </div>
+      </PropExample>
+
+      <PropExample name='.row.gutters-vertical'>
+        <div className='row gutters-vertical'>
+          <div className='col-6'>
+            <Placeholder className='example-grid-block'>.col-6</Placeholder>
+          </div>
+          <div className='col-6'>
+            <Placeholder className='example-grid-block'>.col-6</Placeholder>
+          </div>
+        </div>
+
+        <div className='row gutters-vertical'>
+          <div className='col-sm-12 col-md-4'>
+            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+          </div>
+          <div className='col-sm-12 col-md-4'>
+            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+          </div>
+          <div className='col-sm-12 col-md-4'>
+            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+          </div>
+        </div>
+
+        <div className='row gutters-vertical'>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+          <div className='col-md'>
+            <Placeholder className='example-grid-block'>.col-md</Placeholder>
+          </div>
+        </div>
+      </PropExample>
+
+      <PropExample name='.row.small-gutters'>
+        <div className='row small-gutters'>
+          <div className='col-6'>
+            <Placeholder className='example-grid-block'>.col-6</Placeholder>
+          </div>
+          <div className='col-6'>
+            <Placeholder className='example-grid-block'>.col-6</Placeholder>
+          </div>
+
+          <div className='col-sm-12 col-md-4'>
+            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+          </div>
+          <div className='col-sm-12 col-md-4'>
+            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+          </div>
+          <div className='col-sm-12 col-md-4'>
+            <Placeholder className='example-grid-block'>.col-sm-12.col-md-4</Placeholder>
+          </div>
+
           <div className='col-md'>
             <Placeholder className='example-grid-block'>.col-md</Placeholder>
           </div>
@@ -284,7 +404,7 @@ storiesOf('Foundation|Grid', module)
 
       <PropExample name='.container / .container-fluid / .uncontainer'>
         <div className='uncontainer'>
-          <div className='container mc-mb-4'>
+          <div className='container gutters mc-mb-4'>
             <h5 className='mc-text-h5'>Contained Content</h5>
             <p className='mc-opacity--muted'>
               Containers will keep the edge of your content lined up, as well
@@ -293,7 +413,7 @@ storiesOf('Foundation|Grid', module)
             </p>
           </div>
 
-          <div className='container-fluid mc-mb-4'>
+          <div className='container-fluid gutters mc-mb-4'>
             <h5 className='mc-text-h5'>Fluidly Contained Content</h5>
             <p className='mc-opacity--muted'>
               Identical to a normal container, but the width does not max out.

--- a/src/styles/libraries/bootstrap-grid/_grid.scss
+++ b/src/styles/libraries/bootstrap-grid/_grid.scss
@@ -28,19 +28,6 @@
   .row {
     @include make-row();
   }
-
-  // Remove the negative margin from default .row, then the horizontal padding
-  // from all immediate children columns (to prevent runaway style inheritance).
-  .no-gutters {
-    margin-right: 0;
-    margin-left: 0;
-
-    > .col,
-    > [class*="col-"] {
-      padding-right: 0;
-      padding-left: 0;
-    }
-  }
 }
 
 // Columns

--- a/src/styles/libraries/bootstrap-grid/mixins/_grid-framework.scss
+++ b/src/styles/libraries/bootstrap-grid/mixins/_grid-framework.scss
@@ -9,8 +9,8 @@
     position: relative;
     width: 100%;
     min-height: 1px; // Prevent columns from collapsing when empty
-    padding-right: ($gutter / 2);
-    padding-left: ($gutter / 2);
+    //padding-right: ($gutter / 2);
+    //padding-left: ($gutter / 2);
   }
 
   @each $breakpoint in map-keys($breakpoints) {

--- a/src/styles/libraries/bootstrap-grid/mixins/_grid-framework.scss
+++ b/src/styles/libraries/bootstrap-grid/mixins/_grid-framework.scss
@@ -9,8 +9,6 @@
     position: relative;
     width: 100%;
     min-height: 1px; // Prevent columns from collapsing when empty
-    //padding-right: ($gutter / 2);
-    //padding-left: ($gutter / 2);
   }
 
   @each $breakpoint in map-keys($breakpoints) {

--- a/src/styles/libraries/bootstrap-grid/mixins/_grid.scss
+++ b/src/styles/libraries/bootstrap-grid/mixins/_grid.scss
@@ -4,8 +4,6 @@
 
 @mixin make-container() {
   width: 100%;
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
   margin-right: auto;
   margin-left: auto;
 }
@@ -23,8 +21,6 @@
 @mixin make-row() {
   display: flex;
   flex-wrap: wrap;
-  margin-right: ($grid-gutter-width / -2);
-  margin-left: ($grid-gutter-width / -2);
 }
 
 @mixin make-col-ready() {
@@ -34,8 +30,6 @@
   // later on to override this initial width.
   width: 100%;
   min-height: 1px; // Prevent collapsing
-  padding-right: ($grid-gutter-width / 2);
-  padding-left: ($grid-gutter-width / 2);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {

--- a/src/styles/libraries/bootstrap-overrides/_grid.scss
+++ b/src/styles/libraries/bootstrap-overrides/_grid.scss
@@ -1,25 +1,7 @@
-// We need to support responsive gutter sizing, so this
-// override file sets the gutter sizing from mobile to
-// desktop.
-
-
-.container,
-.container-fluid {
-  padding: 0 ($grid-gutter-width);
-}
-
 .row {
-  margin: $grid-gutter-width / -2;
-
   &--fill {
     height: 100%;
   }
-}
-
-.col,
-[class^="col-"],
-[class*=" col-"] {
-  padding: $grid-gutter-width / 2;
 }
 
 .col-auto-max {
@@ -27,61 +9,75 @@
   max-width: 100%;
 }
 
-// Responsive
-@media only screen and (min-width: $mc-bp-sm) {
-  .container,
-  .container-fluid { padding: 0 ($grid-gutter-width-sm * 2); }
+// Grid modifiers
+.gutters {
+  &.container,
+  &.container-fluid {
+    padding: 0 ($grid-gutter-width);
+  }
+
+  &.row{
+    margin: $grid-gutter-width / -2;
+
+    > .col,
+    > [class^="col-"],
+    > [class*=" col-"] {
+      padding: $grid-gutter-width / 2;
+    }
+  }
+
+  // Responsive
+  @media only screen and (min-width: $mc-bp-sm) {
+    &.container,
+    &.container-fluid { padding: 0 ($grid-gutter-width-sm * 2); }
+  }
+
+  @media only screen and (min-width: $mc-bp-md) {
+    &.container,
+    &.container-fluid { padding: 0 ($grid-gutter-width-md * 2); }
+  }
+
+  @media only screen and (min-width: $mc-bp-lg) {
+    &.container,
+    &.container-fluid { padding: 0 ($grid-gutter-width-lg * 2); }
+  }
+
+  @media only screen and (min-width: $mc-bp-xl) {
+    &.container,
+    &.container-fluid { padding: 0 ($grid-gutter-width-xl * 2); }
+    &.row { margin: $grid-gutter-width-xl / -2; }
+  }
 }
 
-@media only screen and (min-width: $mc-bp-md) {
-  .container,
-  .container-fluid { padding: 0 ($grid-gutter-width-md * 2); }
+.gutters-vertical {
+  &.row{
+    > .col,
+    > [class^="col-"],
+    > [class*=" col-"] {
+      padding: $grid-gutter-width / 2 0;
+    }
+  }
 }
 
-@media only screen and (min-width: $mc-bp-lg) {
-  .container,
-  .container-fluid { padding: 0 ($grid-gutter-width-lg * 2); }
+.gutters-horizontal {
+  &.row{
+    margin: 0 $grid-gutter-width / -2;
+
+    > .col,
+    > [class^="col-"],
+    > [class*=" col-"] {
+      padding-left: $grid-gutter-width / 2;
+      padding-right: $grid-gutter-width / 2;
+    }
+  }
 }
 
-@media only screen and (min-width: $mc-bp-xl) {
-  .container,
-  .container-fluid { padding: 0 ($grid-gutter-width-xl * 2); }
-  .row { margin: $grid-gutter-width-xl / -2; }
-
-  .col,
-  [class^="col-"],
-  [class*=" col-"] { padding: $grid-gutter-width-xl / 2; }
-
-  // Override for smaller gutters when using the
-  // grid inside of an existing column (nested grids)
-  .small-gutters {
+.small-gutters {
+  &.row {
     margin: $grid-gutter-width-xl / -4;
 
-    .col,
+    > .col,
     [class^="col-"],
     [class*=" col-"] { padding: $grid-gutter-width-xl / 4; }
-  }
-}
-
-// Grid modifiers
-.no-gutters {
-  margin: 0;
-
-  > .col,
-  > [class^="col-"],
-  > [class*=" col-"] {
-    padding: 0;
-  }
-}
-
-.no-gutters-vertical {
-  margin-top: 0;
-  margin-bottom: 0;
-
-  > .col,
-  > [class^="col-"],
-  > [class*=" col-"] {
-    padding-top: 0;
-    padding-bottom: 0;
   }
 }


### PR DESCRIPTION
## Overview
Removing default gutters/margin/padding from containers.  Adding new classes to handle cases where gutters are desired

## Risks
Medium - I'll have to go through the MC repo and add gutters classes probably everywhere so as not to impact the desired layouts

## Changes
Before:
![image](https://user-images.githubusercontent.com/56046844/67413891-e77a2a80-f576-11e9-8e8d-f30db9474a86.png)

After:
![image](https://user-images.githubusercontent.com/56046844/67413939-fcef5480-f576-11e9-9f14-43742438cc63.png)

## Issue
https://github.com/yankaindustries/mc-components/issues/458

## Breaking change?
It can be a breaking change - will require gutters classes to be add all over the MC layouts in order not to break stuffs