### PR TITLE
Fix hr text modifier color

### DIFF
--- a/src/styles/base/_theme-css-vars.scss
+++ b/src/styles/base/_theme-css-vars.scss
@@ -59,7 +59,7 @@
   // Main colors
   --mc-theme-background:              #{$mc-color-light};
   --mc-theme-text:                    #{$mc-color-dark};
-  --mc-theme-text-hr-span-after:      #{$mc-color-gray-600};
+  --mc-theme-text-hr-span-after:      #{rgba($mc-color-dark, 0.3)};
   --mc-theme-separator:               #{rgba($mc-color-dark, 0.3)};
   --mc-theme-border-contrast:         #{rgba($mc-color-dark, 0.5)};
   --mc-theme-border-contrast-hover:   #{$mc-color-dark};


### PR DESCRIPTION
## Overview
Fixing hr text modifier inverted color according to Figma's design.

<img width="1201" alt="Screen Shot 2019-10-28 at 11 38 27" src="https://user-images.githubusercontent.com/18464392/67690904-783c7600-f97c-11e9-8eae-ecaaa2e1108d.png">
