### PR TITLE
Adding icon sizing documentation

### DIFF
--- a/src/components/Icons/index.stories.js
+++ b/src/components/Icons/index.stories.js
@@ -26,6 +26,50 @@ storiesOf('Components|Icons', module)
         title='Icon'
         description='Hieroglyphics for the modern age.'
       />
+      <DocSection title='Sizing'>
+        <p className='mc-mb-5'>
+          Use the supporting className format
+          <span className='mc-code mc-mx-2'>
+            className=&apos;mc-icon--x&apos;
+          </span>
+          where
+          <span className='mc-code mc-mx-2'>
+            x
+          </span>
+          is a value between 1-16 correlating to the&nbsp;
+          <a
+            href='?path=/story/foundation-scale--summary'
+            className='mc-text--link'
+          >scale</a>.
+        </p>
+
+        <div className='row'>
+          <div className='col-auto'>
+            <h5 className='mc-text-h5'>
+              <span className='mc-code'>mc-icon--1</span>
+            </h5>
+            <Icon kind='star' className='mc-icon--1' />
+          </div>
+          <div className='col-auto'>
+            <h5 className='mc-text-h5'>
+              <span className='mc-code'>mc-icon--5</span>
+            </h5>
+            <Icon kind='star' className='mc-icon--5' />
+          </div>
+          <div className='col-auto'>
+            <h5 className='mc-text-h5'>
+              <span className='mc-code'>mc-icon--9</span>
+            </h5>
+            <Icon kind='star' className='mc-icon--9' />
+          </div>
+          <div className='col-auto'>
+            <h5 className='mc-text-h5'>
+              <span className='mc-code'>mc-icon--10</span>
+            </h5>
+            <Icon kind='star' className='mc-icon--10' />
+          </div>
+        </div>
+      </DocSection>
 
       <DocSection title='Properties'>
         <InvertedMirror>

--- a/src/components/Icons/index.stories.js
+++ b/src/components/Icons/index.stories.js
@@ -7,6 +7,7 @@ import DocHeader from '../../utils/DocHeader'
 import DocSection from '../../utils/DocSection'
 import InvertedMirror from '../../utils/InvertedMirror'
 import PropExample from '../../utils/PropExample'
+import CodeExample from '../../utils/CodeExample'
 
 import Icon from '../Icons'
 import { ICONS } from './icons'
@@ -40,35 +41,39 @@ storiesOf('Components|Icons', module)
           <a
             href='?path=/story/foundation-scale--summary'
             className='mc-text--link'
-          >scale</a>.
+          >
+            scale
+          </a>.
         </p>
 
-        <div className='row'>
-          <div className='col-auto'>
-            <h5 className='mc-text-h5'>
-              <span className='mc-code'>mc-icon--1</span>
-            </h5>
-            <Icon kind='star' className='mc-icon--1' />
+        <CodeExample>
+          <div className='row'>
+            <div className='col-auto'>
+              <h5 className='mc-text-h5'>
+                <span className='mc-code'>mc-icon--1</span>
+              </h5>
+              <Icon kind='star' className='mc-icon--1' />
+            </div>
+            <div className='col-auto'>
+              <h5 className='mc-text-h5'>
+                <span className='mc-code'>mc-icon--5</span>
+              </h5>
+              <Icon kind='star' className='mc-icon--5' />
+            </div>
+            <div className='col-auto'>
+              <h5 className='mc-text-h5'>
+                <span className='mc-code'>mc-icon--9</span>
+              </h5>
+              <Icon kind='star' className='mc-icon--9' />
+            </div>
+            <div className='col-auto'>
+              <h5 className='mc-text-h5'>
+                <span className='mc-code'>mc-icon--10</span>
+              </h5>
+              <Icon kind='star' className='mc-icon--10' />
+            </div>
           </div>
-          <div className='col-auto'>
-            <h5 className='mc-text-h5'>
-              <span className='mc-code'>mc-icon--5</span>
-            </h5>
-            <Icon kind='star' className='mc-icon--5' />
-          </div>
-          <div className='col-auto'>
-            <h5 className='mc-text-h5'>
-              <span className='mc-code'>mc-icon--9</span>
-            </h5>
-            <Icon kind='star' className='mc-icon--9' />
-          </div>
-          <div className='col-auto'>
-            <h5 className='mc-text-h5'>
-              <span className='mc-code'>mc-icon--10</span>
-            </h5>
-            <Icon kind='star' className='mc-icon--10' />
-          </div>
-        </div>
+        </CodeExample>
       </DocSection>
 
       <DocSection title='Properties'>

--- a/src/foundation/utilities/theme.stories.js
+++ b/src/foundation/utilities/theme.stories.js
@@ -5,6 +5,7 @@ import DocHeader from '../../utils/DocHeader'
 import DocSection from '../../utils/DocSection'
 import Button from '../../components/Button'
 import Background from '../../components/Background'
+import CodeExample from '../../utils/CodeExample'
 
 
 const Theme = () =>
@@ -28,50 +29,7 @@ const Theme = () =>
         </span>
          or no specific class set
       </h6>
-      <div className='row'>
-        <div className='col-4'>
-          <Button kind='primary'>
-            Button
-          </Button>
-        </div>
-
-        <div className='col-4'>
-          <Button kind='secondary'>
-            Button
-          </Button>
-        </div>
-
-        <div className='col-4'>
-          <Button kind='tertiary'>
-            Button
-          </Button>
-        </div>
-      </div>
-
-      <div className='row'>
-        <div className='col-12'>
-          <p>
-            Sed dolor nulla pariatur laboris nulla sit in sint velit
-            est magna officia deserunt cupidatat commodo ea nostrud
-            occaecat magna adipisicing sed culpa ut fugiat non minim
-            ut sint laboris est laboris commodo tempor excepteur
-            non pariatur.
-          </p>
-        </div>
-      </div>
-    </DocSection>
-
-    <DocSection title='Light theme'>
-      <h6 className='mc-text-h6 mc-mb-6'>
-        <span className='mc-code mc-mr-3'>
-          className=&apos;mc-theme-light&apos;
-        </span>
-      </h6>
-
-      <Background
-        color='light'
-        className='mc-theme-light mc-p-4'
-      >
+      <CodeExample>
         <div className='row'>
           <div className='col-4'>
             <Button kind='primary'>
@@ -103,40 +61,67 @@ const Theme = () =>
             </p>
           </div>
         </div>
-      </Background>
+      </CodeExample>
+    </DocSection>
+
+    <DocSection title='Light theme'>
+      <h6 className='mc-text-h6 mc-mb-6'>
+        <span className='mc-code mc-mr-3'>
+          className=&apos;mc-theme-light&apos;
+        </span>
+      </h6>
+
+      <CodeExample>
+        <Background
+          color='light'
+          className='mc-theme-light mc-p-4'
+        >
+          <div className='row'>
+            <div className='col-4'>
+              <Button kind='primary'>
+                Button
+              </Button>
+            </div>
+
+            <div className='col-4'>
+              <Button kind='secondary'>
+                Button
+              </Button>
+            </div>
+
+            <div className='col-4'>
+              <Button kind='tertiary'>
+                Button
+              </Button>
+            </div>
+          </div>
+
+          <div className='row'>
+            <div className='col-12'>
+              <p>
+                Sed dolor nulla pariatur laboris nulla sit in sint velit
+                est magna officia deserunt cupidatat commodo ea nostrud
+                occaecat magna adipisicing sed culpa ut fugiat non minim
+                ut sint laboris est laboris commodo tempor excepteur
+                non pariatur.
+              </p>
+            </div>
+          </div>
+        </Background>
+      </CodeExample>
     </DocSection>
 
     <DocSection title='Nested themes'>
-      <Background
-        color='light'
-        className='mc-theme-light mc-p-4 mc-mt-4'
-      >
-        <h6 className='mc-text-h6 mc-mb-6'>
-          <span className='mc-code mc-mr-3'>
-            className=&apos;mc-theme-light&apos;
-          </span>
-        </h6>
-        <p>
-          Sed dolor nulla pariatur laboris nulla sit in sint velit
-          est magna officia deserunt cupidatat commodo ea nostrud
-          occaecat magna adipisicing sed culpa ut fugiat non minim
-          ut sint laboris est laboris commodo tempor excepteur
-          non pariatur.
-        </p>
-        <Button kind='tertiary' size='small' className='mc-mt-3'>
-          Button
-        </Button>
-
+      <CodeExample>
         <Background
-          color='dark'
-          className='mc-theme-dark mc-p-4 mc-mt-4'
+          color='light'
+          className='mc-theme-light mc-p-4 mc-mt-4'
         >
           <h6 className='mc-text-h6 mc-mb-6'>
             <span className='mc-code mc-mr-3'>
-              className=&apos;mc-theme-dark&apos;
+              className=&apos;mc-theme-light&apos;
             </span>
           </h6>
-
           <p>
             Sed dolor nulla pariatur laboris nulla sit in sint velit
             est magna officia deserunt cupidatat commodo ea nostrud
@@ -144,18 +129,17 @@ const Theme = () =>
             ut sint laboris est laboris commodo tempor excepteur
             non pariatur.
           </p>
-
           <Button kind='tertiary' size='small' className='mc-mt-3'>
             Button
           </Button>
 
           <Background
-            color='light'
-            className='mc-theme-light mc-p-4 mc-mt-4'
+            color='dark'
+            className='mc-theme-dark mc-p-4 mc-mt-4'
           >
             <h6 className='mc-text-h6 mc-mb-6'>
               <span className='mc-code mc-mr-3'>
-                className=&apos;mc-theme-light&apos;
+                className=&apos;mc-theme-dark&apos;
               </span>
             </h6>
 
@@ -166,12 +150,35 @@ const Theme = () =>
               ut sint laboris est laboris commodo tempor excepteur
               non pariatur.
             </p>
+
             <Button kind='tertiary' size='small' className='mc-mt-3'>
               Button
             </Button>
+
+            <Background
+              color='light'
+              className='mc-theme-light mc-p-4 mc-mt-4'
+            >
+              <h6 className='mc-text-h6 mc-mb-6'>
+                <span className='mc-code mc-mr-3'>
+                  className=&apos;mc-theme-light&apos;
+                </span>
+              </h6>
+
+              <p>
+                Sed dolor nulla pariatur laboris nulla sit in sint velit
+                est magna officia deserunt cupidatat commodo ea nostrud
+                occaecat magna adipisicing sed culpa ut fugiat non minim
+                ut sint laboris est laboris commodo tempor excepteur
+                non pariatur.
+              </p>
+              <Button kind='tertiary' size='small' className='mc-mt-3'>
+                Button
+              </Button>
+            </Background>
           </Background>
         </Background>
-      </Background>
+      </CodeExample>
     </DocSection>
   </div>
 

--- a/src/styles/base/_theme-css-vars.scss
+++ b/src/styles/base/_theme-css-vars.scss
@@ -59,7 +59,7 @@
   // Main colors
   --mc-theme-background:              #{$mc-color-light};
   --mc-theme-text:                    #{$mc-color-dark};
-  --mc-theme-text-hr-span-after:      #{$mc-color-gray-600};
+  --mc-theme-text-hr-span-after:      #{rgba($mc-color-dark, 0.3)};
   --mc-theme-separator:               #{rgba($mc-color-dark, 0.3)};
   --mc-theme-border-contrast:         #{rgba($mc-color-dark, 0.5)};
   --mc-theme-border-contrast-hover:   #{$mc-color-dark};


### PR DESCRIPTION
## Overview
Add better documentation for the icon sizing class helpers
![image](https://user-images.githubusercontent.com/505670/67805122-9920cc00-fa4d-11e9-9f80-1840a55fe2ff.png)

## Risks
None - documentation change only

## Changes
Adds documentation to icon sizing

## Issue
https://github.com/yankaindustries/mc-components/issues/532

## Breaking change?
Backwards Compatible