### PR TITLE
Dropdown - Fixing close functionality

### DIFF
--- a/src/components/Dropdown/index.stories.js
+++ b/src/components/Dropdown/index.stories.js
@@ -61,7 +61,9 @@ class Controlled extends PureComponent {
         <div className='col-auto'>
           <Dropdown placement='bottom-end'>
             <DropdownToggle>
-              <Button>Controlled</Button>
+              <Button onClick={this.toggleShow}>
+                Controlled
+              </Button>
             </DropdownToggle>
 
             <DropdownContentControlled

--- a/src/components/Dropdown/index.stories.js
+++ b/src/components/Dropdown/index.stories.js
@@ -35,17 +35,59 @@ const CATEGORIES = [
 ]
 
 
-class DropdownStory extends PureComponent {
+class Controlled extends PureComponent {
   state = {
     show: false,
   }
 
   toggleShow = () =>
+    console.log('toggleShow') ||
     this.setState(prevState => ({ show: !prevState.show }))
 
   render () {
     const { show } = this.state
 
+    return (
+      <div className='row'>
+        <div className='col-auto'>
+          <Button
+            kind='secondary'
+            onClick={this.toggleShow}
+          >
+            Controller
+          </Button>
+        </div>
+
+        <div className='col-auto'>
+          <Dropdown placement='bottom-end'>
+            <DropdownToggle>
+              <Button>Controlled</Button>
+            </DropdownToggle>
+
+            <DropdownContentControlled
+              show={show}
+              onClose={this.toggleShow}
+            >
+              {CATEGORIES.map((category, key) =>
+                <DropdownItem
+                  key={key}
+                  className='mc-py-3 mc-px-5 mc-text-small'
+                  onClick={this.toggleShow}
+                >
+                  {category}
+                </DropdownItem>,
+              )}
+            </DropdownContentControlled>
+          </Dropdown>
+        </div>
+      </div>
+    )
+  }
+}
+
+
+class DropdownStory extends PureComponent {
+  render () {
     return (
       <div className='container'>
         <DocHeader
@@ -54,17 +96,6 @@ class DropdownStory extends PureComponent {
         />
 
         <DocSection title='Demo'>
-          <div className='row'>
-            <div className='col-sm-3'>
-              <Button
-                kind='secondary'
-                onClick={this.toggleShow}
-              >
-                {show ? 'Hide' : 'Show'}
-              </Button>
-            </div>
-          </div>
-
           <InvertedMirror>
             <CodeExample>
               <div className='row justify-content-center'>
@@ -79,6 +110,7 @@ class DropdownStory extends PureComponent {
                         <DropdownItem
                           key={key}
                           className='mc-py-3 mc-px-5 mc-text-small'
+                          closeOnClick
                         >
                           {category}
                         </DropdownItem>,
@@ -98,6 +130,7 @@ class DropdownStory extends PureComponent {
                         <DropdownItem key={key}
                           className='mc-py-3 mc-px-5 mc-text-small'
                           onClick={action('item')}
+                          closeOnClick
                         >
                           <div className='row align-items-center'>
                             <div className='col-4'>
@@ -181,26 +214,7 @@ class DropdownStory extends PureComponent {
                 </div>
 
                 <div className='col-auto'>
-                  <Dropdown placement='bottom-end'>
-                    <DropdownToggle>
-                      <Button>Controlled</Button>
-                    </DropdownToggle>
-
-                    <DropdownContentControlled
-                      show={show}
-                      onClose={this.toggleShow}
-                    >
-                      {CATEGORIES.map((category, key) =>
-                        <DropdownItem
-                          key={key}
-                          className='mc-py-3 mc-px-5 mc-text-small'
-                          onClick={this.toggleShow}
-                        >
-                          {category}
-                        </DropdownItem>,
-                      )}
-                    </DropdownContentControlled>
-                  </Dropdown>
+                  <Controlled />
                 </div>
               </div>
             </CodeExample>

--- a/src/components/DropdownItem/index.js
+++ b/src/components/DropdownItem/index.js
@@ -10,6 +10,7 @@ export default class DropdownItem extends PureComponent {
   static propTypes = {
     children: PROP_TYPE_CHILDREN,
     className: PropTypes.string,
+    closeOnClick: PropTypes.bool,
     onClick: PropTypes.func,
   }
 
@@ -18,7 +19,10 @@ export default class DropdownItem extends PureComponent {
   }
 
   handleClick = toggle => (event) => {
-    toggle(event)
+    if (this.props.closeOnClick) {
+      toggle(event)
+    }
+
     this.props.onClick(event)
   }
 

--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -58,6 +58,12 @@ export const renderChildren = (children, props) => {
       ...child.props,
       ...props,
       className: `${child.props.className || ''} ${props.className || ''}`,
+      onClick: child.props.onClick || props.onClick
+        ? (event) => {
+          if (child.props.onClick) { child.props.onClick(event) }
+          if (props.onClick) { props.onClick(event) }
+        }
+        : undefined,
     }),
   )
 

--- a/src/styles/helpers/_opacity.scss
+++ b/src/styles/helpers/_opacity.scss
@@ -1,6 +1,6 @@
 // stylelint-disable declaration-no-important
 .mc-opacity {
   &--hinted { opacity: 0.8 !important; }
-  &--muted { opacity: 0.5 !important; }
+  &--muted { opacity: 0.6 !important; }
   &--silenced { opacity: 0.3 !important; }
 }


### PR DESCRIPTION
## Overview
`DropdownItem` automatically closes the dropdown when you click on it.  This should have been an opt-in prop, but I made it automatic.  This PR fixes that.

Additionally, `onClick` for the child of `<DropdownToggle>` was being overridden making it impossible for a controlled dropdown to be opened by it's own toggle.  `renderChildren` was extended to support firing the `onClick` of both the DropdownToggle and child.

## Risks
Low - we will need to update existing implementations if autoclosing is expected

## Breaking change?
Breaking - requires update in existing implementation
