### PR TITLE
Update 'as' proptype in Button to support React components

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -10,6 +10,8 @@ export default class Button extends PureComponent {
     as: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.element,
+      PropTypes.node,
+      PropTypes.func,
     ]),
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),


### PR DESCRIPTION
## Overview
Example with `react-router`'s Link component:

```javascript
import { Link } from 'react-router'

<Button as={Link} to={path.myPathname}>Link to path</Button>
```

## Risks
None

## Changes
Update Button component proptypes
