### PR TITLE
BUG: maxlength text wasn't working for TextArea component

### DIFF
--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -81,7 +81,7 @@ export default class FormGroup extends PureComponent {
             {children}
           </div>
 
-          <div className='col align-self-start'>
+          <div className='col-auto align-self-start flex-fill'>
             {state === STATE_DEFAULT &&
               <p className='mc-text-x-small mc-opacity--muted mc-text--left mc-mt-1'>
                 {help}
@@ -102,7 +102,7 @@ export default class FormGroup extends PureComponent {
             }
           </div>
 
-          <div className='col-auto align-self-start'>
+          <div className='col-auto align-self-end flex-fill'>
             {maxlength &&
               <p className='mc-text-x-small mc-opacity--muted mc-text--right mc-mt-1'>
                 {value.length} / {maxlength}

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -108,6 +108,7 @@ const Form = reduxForm({
                   `}
                   placeholder='This is the story of a girl...'
                   success='Dope!'
+                  maxlength={80}
                   optional
                 />
               </div>

--- a/src/components/TextareaField/index.js
+++ b/src/components/TextareaField/index.js
@@ -32,6 +32,7 @@ const TextareaField = ({
       optional={optional}
       success={success}
       touched={touched}
+      value={input.value}
     >
       <Textarea
         error={error}


### PR DESCRIPTION
## Overview
Fixes:
• Include the input value to calculate the length
• Add an example
• Fix alignment when the text helper isn't present

## Risks
None. We are not using the max length validation yet.