### PR TITLE
Revert "BUG: maxlength text wasn't working for TextArea component"

### DIFF
--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -81,7 +81,7 @@ export default class FormGroup extends PureComponent {
             {children}
           </div>
 
-          <div className='col-auto align-self-start flex-fill'>
+          <div className='col align-self-start'>
             {state === STATE_DEFAULT &&
               <p className='mc-text-x-small mc-opacity--muted mc-text--left mc-mt-1'>
                 {help}
@@ -102,7 +102,7 @@ export default class FormGroup extends PureComponent {
             }
           </div>
 
-          <div className='col-auto align-self-end flex-fill'>
+          <div className='col-auto align-self-start'>
             {maxlength &&
               <p className='mc-text-x-small mc-opacity--muted mc-text--right mc-mt-1'>
                 {value.length} / {maxlength}

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -108,7 +108,6 @@ const Form = reduxForm({
                   `}
                   placeholder='This is the story of a girl...'
                   success='Dope!'
-                  maxlength={80}
                   optional
                 />
               </div>

--- a/src/components/TextareaField/index.js
+++ b/src/components/TextareaField/index.js
@@ -32,7 +32,6 @@ const TextareaField = ({
       optional={optional}
       success={success}
       touched={touched}
-      value={input.value}
     >
       <Textarea
         error={error}


### PR DESCRIPTION
Reverts yankaindustries/mc-components#613

![image](https://user-images.githubusercontent.com/505670/68237847-dee51380-ffbc-11e9-8ffd-82ba95c934e8.png)

Introduced a minor regression in wrapping for text counter form input.  @bernabe9 to submit new PR following this revert.