### PR TITLE
Fix textarea maxlength value and alignment

### DIFF
--- a/src/components/FormGroup/index.js
+++ b/src/components/FormGroup/index.js
@@ -102,7 +102,7 @@ export default class FormGroup extends PureComponent {
             }
           </div>
 
-          <div className='col-auto align-self-start'>
+          <div className='col-auto align-self-start mc-ml-auto'>
             {maxlength &&
               <p className='mc-text-x-small mc-opacity--muted mc-text--right mc-mt-1'>
                 {value.length} / {maxlength}

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -107,6 +107,7 @@ const Form = reduxForm({
                     but we prefer anything.
                   `}
                   placeholder='This is the story of a girl...'
+                  success='Dope!'
                   maxlength={80}
                   optional
                 />

--- a/src/components/Forms/index.stories.js
+++ b/src/components/Forms/index.stories.js
@@ -107,7 +107,7 @@ const Form = reduxForm({
                     but we prefer anything.
                   `}
                   placeholder='This is the story of a girl...'
-                  success='Dope!'
+                  maxlength={80}
                   optional
                 />
               </div>

--- a/src/components/TextareaField/index.js
+++ b/src/components/TextareaField/index.js
@@ -32,6 +32,7 @@ const TextareaField = ({
       optional={optional}
       success={success}
       touched={touched}
+      value={input.value}
     >
       <Textarea
         error={error}

--- a/src/styles/helpers/_spacing-margin.scss
+++ b/src/styles/helpers/_spacing-margin.scss
@@ -41,6 +41,8 @@
   @for $i from $scale-begin through $scale-end {
     &-#{$i} { @include step(margin-top, $i); }
   }
+
+  &-auto { margin-top: auto; }
 }
 
 // Margins - right only
@@ -48,6 +50,8 @@
   @for $i from $scale-begin through $scale-end {
     &-#{$i} { @include step(margin-right, $i); }
   }
+
+  &-auto { margin-right: auto; }
 }
 
 // Margins - bottom only
@@ -55,6 +59,8 @@
   @for $i from $scale-begin through $scale-end {
     &-#{$i} { @include step(margin-bottom, $i); }
   }
+
+  &-auto { margin-bottom: auto; }
 }
 
 // Margins - left only
@@ -62,4 +68,6 @@
   @for $i from $scale-begin through $scale-end {
     &-#{$i} { @include step(margin-left, $i); }
   }
+
+  &-auto { margin-left: auto; }
 }

--- a/src/styles/helpers/_spacing-margin.scss
+++ b/src/styles/helpers/_spacing-margin.scss
@@ -24,6 +24,11 @@
       @include step(margin-right, $i);
     }
   }
+
+  &-auto {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 // Margins - y axis only
@@ -33,6 +38,11 @@
       @include step(margin-top, $i);
       @include step(margin-bottom, $i);
     }
+  }
+
+  &-auto {
+    margin-top: auto;
+    margin-bottom: auto;
   }
 }
 


### PR DESCRIPTION
## Overview
The `maxlength` prop for TextArea (the character count label) was being pulled to the left alignment when there was no helper text displayed.

This PR:
- Adds margin auto helpers (`mc-ml-auto`, others)
- Fixes alignment of the maxlength text to the right of the box when there is no supporting text in the left

## Risks
None

## Changes
New margin helpers for "auto"! for Top, Right, Left, Bottom, X, and Y

## Issue
N/A

## Breaking change?
Backwards compatible