### PR TITLE
Passing all props from VideoPlayer onto video tag

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -452,6 +452,7 @@ export default class VideoPlayer extends PureComponent {
             data-video-id={videoId}
             muted={isMuted}
             controls={hasControls}
+            {...this.props}
           />
         </div>
 

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -414,6 +414,7 @@ export default class VideoPlayer extends PureComponent {
 
       hasControls,
       isMuted,
+      ...restProps,
     } = this.props
 
     const {
@@ -452,7 +453,7 @@ export default class VideoPlayer extends PureComponent {
             data-video-id={videoId}
             muted={isMuted}
             controls={hasControls}
-            {...this.props}
+            {...restProps}
           />
         </div>
 

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -414,7 +414,7 @@ export default class VideoPlayer extends PureComponent {
 
       hasControls,
       isMuted,
-      ...restProps,
+      ...restProps
     } = this.props
 
     const {


### PR DESCRIPTION
## Overview
As common practice, I added passing the props from wrapper component VideoPlayer onto video player tag.

## Risks
Low

## Changes
<How does this PR affect existing components? Please show screenshots or GIFs>
Just code-wise, any extra prop shouldn't bother with the video tag.
