### PR TITLE
Mobile Safari bug

### DIFF
--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -83,7 +83,6 @@
   }
 
   &__body--open {
-    position: fixed;
     overflow: hidden;
     height: 100vh;
     width: 100vw;


### PR DESCRIPTION
## Overview
Modals on safari are being cut off.

If you start scrolling down, and you try to open a modal, you'll see that it is cut off depending on your current position. 

## Risks
Low

## Changes
removed `position: fixed` on `mc-modal__body--open` class.

## Screenshots
<img width="325" alt="Screen Shot 2019-11-11 at 4 29 01 PM" src="https://user-images.githubusercontent.com/12576190/68614829-7d331680-04a0-11ea-8738-061c5665ed6c.png">

* Same modal as the previous one, but this time, it was opened from the top
<img width="324" alt="Screen Shot 2019-11-11 at 4 30 05 PM" src="https://user-images.githubusercontent.com/12576190/68614936-c08d8500-04a0-11ea-8f59-00097901d1b3.png">


