### PR TITLE
pulling props out of being passed to dropdown components

### DIFF
--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -95,7 +95,7 @@ export default class Dropdown extends PureComponent {
   applyStyle = (data) => {
     if (window.innerWidth > 576) {
       this.setState({
-        attributes: data.attributes,
+        attributes: { 'x-placement': data.attributes['x-placement'] },
         styles: data.styles,
       })
     }

--- a/src/components/DropdownItem/index.js
+++ b/src/components/DropdownItem/index.js
@@ -30,6 +30,8 @@ export default class DropdownItem extends PureComponent {
     const {
       children,
       className,
+      closeOnClick,
+      onClick,
       ...props
     } = this.props
 
@@ -43,8 +45,8 @@ export default class DropdownItem extends PureComponent {
         {({ toggle }) =>
           <div
             className={classes}
-            {...props}
             onClick={this.handleClick(toggle)}
+            {...props}
           >
             {children}
           </div>


### PR DESCRIPTION
## Overview
Takes care of warnings for passing non-standard HTML attributes to DOM elements (specifically around Dropdown components)

## Risks
None - should not change implementation, just removes warnings