### PR TITLE
Dropdown with Fixed option, to prevent jittery scroll behavior

### DIFF
--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -17,10 +17,12 @@ export const {
 export default class Dropdown extends PureComponent {
   static propTypes = {
     children: PROP_TYPE_CHILDREN,
+    fixed: PropTypes.bool,
     placement: PropTypes.string,
   }
 
   static defaultProps = {
+    fixed: false,
     placement: 'bottom-start',
   }
 
@@ -74,7 +76,7 @@ export default class Dropdown extends PureComponent {
   }
 
   renderDropdown = () => {
-    const { placement } = this.props
+    const { fixed, placement } = this.props
 
 
     this.tooltip = new Popper(
@@ -82,6 +84,7 @@ export default class Dropdown extends PureComponent {
       this.dropdownRef.current,
       {
         placement,
+        positionFixed: fixed,
         modifiers: {
           applyStyle: {
             enabled: true,

--- a/src/components/Dropdown/index.stories.js
+++ b/src/components/Dropdown/index.stories.js
@@ -21,6 +21,8 @@ import DropdownFooter from '../DropdownFooter'
 import Button from '../Button'
 import Icon from '../Icons'
 
+import Sticky from '../Sticky'
+
 import shondaRhimesThumbnail from '../../utils/shonda-rhimes.png'
 
 
@@ -98,6 +100,30 @@ class DropdownStory extends PureComponent {
         />
 
         <DocSection title='Demo'>
+          <CodeExample>
+            <h6 className='mc-text-h6'>Fixed parent dropdown (above)</h6>
+            <Sticky
+              position={'top'}
+            >
+              <Dropdown fixed>
+                <DropdownToggle>
+                  <Button>Fixed Parent</Button>
+                </DropdownToggle>
+                <DropdownContent>
+                  {CATEGORIES.map((category, key) =>
+                    <DropdownItem
+                      key={key}
+                      className='mc-py-3 mc-px-5 mc-text-small'
+                      closeOnClick
+                    >
+                      {category}
+                    </DropdownItem>,
+                  )}
+                </DropdownContent>
+              </Dropdown>
+            </Sticky>
+          </CodeExample>
+
           <InvertedMirror>
             <CodeExample>
               <div className='row justify-content-center'>


### PR DESCRIPTION
## Overview
Adds an optional prop `fixed` for Dropdown, to prevent jittery scrolling behavior. Also adds a fixed parent dropdown to the storybook dropdowns page.

## Risks
Low

## Changes
When you add the optional `fixed` prop on a Dropdown, the dropdown scrolls smoothly attached to its fixed parent rather than jittery because we are passing a fixed option to Popper which we use for dropdowns

## Issue
https://masterclass-dev.atlassian.net/browse/RET-1147

## Breaking change?
Backwards Compatible
