### PR TITLE
Modal body scroll & overflow refactor

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -114,7 +114,9 @@ export default class Modal extends PureComponent {
             kind={backdrop}
           />
           <div className='mc-modal__viewport'>
-            {children}
+            <div className='container'>
+              {children}
+            </div>
           </div>
         </div>
       </Provider>

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -53,10 +53,8 @@ export default class Modal extends PureComponent {
     const rootHtml = document.getElementsByTagName('html')[0]
 
     if (!prevProps.show && show) {
-      document.body.classList.add('mc-modal__body--open')
       rootHtml.classList.add('mc-modal__html--open')
     } else if (prevProps.show && !show) {
-      document.body.classList.remove('mc-modal__body--open')
       rootHtml.classList.remove('mc-modal__html--open')
     }
 

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -50,18 +50,18 @@ export default class Modal extends PureComponent {
 
   componentDidUpdate (prevProps) {
     const { show } = this.props
-
-    // a little hackery here to prevent scrolling/reset
+    const rootHtml = document.getElementsByTagName('html')[0]
 
     if (!prevProps.show && show) {
-      const scrollOffset = window.scrollY
-      document.body.style.top = `-${scrollOffset}px`
       document.body.classList.add('mc-modal__body--open')
+      rootHtml.classList.add('mc-modal__html--open')
     } else if (prevProps.show && !show) {
-      const scrollOffset = -parseInt(document.body.style.top, 10)
       document.body.classList.remove('mc-modal__body--open')
-      document.body.style.top = undefined
-      window.scrollTo(0, scrollOffset)
+      rootHtml.classList.remove('mc-modal__html--open')
+    }
+
+    if (show) {
+      this.container.current.scrollTop = 0
     }
   }
 
@@ -88,6 +88,8 @@ export default class Modal extends PureComponent {
     }
   }
 
+  container = React.createRef()
+
   renderModal = () => {
     const {
       backdrop,
@@ -112,11 +114,10 @@ export default class Modal extends PureComponent {
           <Backdrop
             className='mc-modal__backdrop'
             kind={backdrop}
-          >
-            <div className='container'>
-              {children}
-            </div>
-          </Backdrop>
+          />
+          <div className='mc-modal__viewport'>
+            {children}
+          </div>
         </div>
       </Provider>
     )

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -59,7 +59,10 @@ export default class Modal extends PureComponent {
     }
 
     if (show) {
-      this.container.current.scrollTop = 0
+      const elem = this.container.current
+      window.setTimeout(() => {
+        elem.scrollTop = 0
+      }, 0)
     }
   }
 

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -27,6 +27,7 @@ class ModalExample extends Component {
     rate: false,
     trailer: false,
     welcome: false,
+    scrolling: false,
   }
 
   toggleModal = name => () => {
@@ -44,8 +45,8 @@ class ModalExample extends Component {
         />
 
         <DocSection title='Demo'>
-          <div className='row'>
-            <div className='col-md-3'>
+          <div className='row' style={{ height: '2000px' }}>
+            <div className='col-md-2'>
               <CodeExample>
                 <div className='mc-text--center'>
                   <Button
@@ -91,7 +92,7 @@ class ModalExample extends Component {
               </CodeExample>
             </div>
 
-            <div className='col-md-3'>
+            <div className='col-md-2'>
               <CodeExample>
                 <div className='mc-text--center'>
                   <Button
@@ -167,7 +168,7 @@ class ModalExample extends Component {
               </CodeExample>
             </div>
 
-            <div className='col-md-3'>
+            <div className='col-md-2'>
               <CodeExample>
                 <div className='mc-text--center'>
                   <Button
@@ -226,7 +227,7 @@ class ModalExample extends Component {
               </CodeExample>
             </div>
 
-            <div className='col-md-3'>
+            <div className='col-md-2'>
               <CodeExample>
                 <div className='mc-text--center'>
                   <Button
@@ -262,6 +263,61 @@ class ModalExample extends Component {
                         <Button>All-Access Pass</Button>
                       </div>
                     </div>
+                  </ModalContent>
+                </Modal>
+              </CodeExample>
+            </div>
+
+            <div className='col-md-2'>
+              <CodeExample>
+                <div className='mc-text--center'>
+                  <Button
+                    kind='secondary'
+                    onClick={this.toggleModal('scrolling')}
+                  >
+                    Scrolling
+                  </Button>
+                </div>
+
+                <Modal
+                  backdrop='extra-dark'
+                  show={this.state.scrolling}
+                  onClose={this.toggleModal('scrolling')}
+                  size='small'
+                >
+                  <ModalContent className='mc-theme-light'>
+                    <ModalClose />
+                    <Background
+                      color='light'
+                      className='mc-px-4 mc-py-9 mc-text--center'
+                    >
+                      <div className='row align-items-center justify-content-between'>
+
+                        <div className='col-auto'>
+                          <h6 className='mc-text-h6 mc-text--uppercase'>
+                            Super Long Modal
+                          </h6>
+                          <p
+                            className='mc-opacity--muted'
+                            style={{ height: '400px' }}
+                          >
+                            Seems to stretch...
+                          </p>
+                          <p
+                            className='mc-opacity--muted'
+                            style={{ height: '400px' }}
+                          >
+                            Forever...
+                          </p>
+                          <p
+                            className='mc-opacity--muted'
+                            style={{ height: '1000px' }}
+                          >
+                            ...
+                          </p>
+                        </div>
+                      </div>
+                    </Background>
                   </ModalContent>
                 </Modal>
               </CodeExample>

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -283,34 +283,34 @@ class ModalExample extends Component {
                   backdrop='extra-dark'
                   show={this.state.scrolling}
                   onClose={this.toggleModal('scrolling')}
-                  size='small'
+                  size='medium'
                 >
                   <ModalContent className='mc-theme-light'>
                     <ModalClose />
                     <Background
                       color='light'
-                      className='mc-px-4 mc-py-9 mc-text--center'
+                      className='mc-px-4 mc-py-9'
                     >
                       <div className='row align-items-center justify-content-between'>
 
-                        <div className='col-auto'>
-                          <h6 className='mc-text-h6 mc-text--uppercase'>
+                        <div className='offset-sm-1 col-sm-10'>
+                          <h6 className='mc-text-h2 mc-text--uppercase mc-text--center'>
                             Super Long Modal
                           </h6>
                           <p
-                            className='mc-opacity--muted'
+                            className='mc-opacity--muted mc-text--center'
                             style={{ height: '400px' }}
                           >
                             Seems to stretch...
                           </p>
                           <p
-                            className='mc-opacity--muted'
+                            className='mc-opacity--muted mc-text--center'
                             style={{ height: '400px' }}
                           >
                             Forever...
                           </p>
                           <p
-                            className='mc-opacity--muted'
+                            className='mc-opacity--muted mc-text--center'
                             style={{ height: '1000px' }}
                           >
                             ...

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -297,22 +297,13 @@ class ModalExample extends Component {
                           <h6 className='mc-text-h2 mc-text--uppercase mc-text--center'>
                             Super Long Modal
                           </h6>
-                          <p
-                            className='mc-opacity--muted mc-text--center'
-                            style={{ height: '400px' }}
-                          >
+                          <p className='mc-opacity--muted mc-text--center'>
                             Seems to stretch...
                           </p>
-                          <p
-                            className='mc-opacity--muted mc-text--center'
-                            style={{ height: '400px' }}
-                          >
+                          <p className='mc-opacity--muted mc-text--center'>
                             Forever...
                           </p>
-                          <p
-                            className='mc-opacity--muted mc-text--center'
-                            style={{ height: '1000px' }}
-                          >
+                          <p className='mc-opacity--muted mc-text--center'>
                             ...
                           </p>
                         </div>
@@ -321,6 +312,7 @@ class ModalExample extends Component {
                   </ModalContent>
                 </Modal>
               </CodeExample>
+              <div style={{ height: '1500px' }} />
             </div>
           </div>
         </DocSection>

--- a/src/components/Modal/index.stories.js
+++ b/src/components/Modal/index.stories.js
@@ -45,7 +45,7 @@ class ModalExample extends Component {
         />
 
         <DocSection title='Demo'>
-          <div className='row' style={{ height: '2000px' }}>
+          <div className='row'>
             <div className='col-md-2'>
               <CodeExample>
                 <div className='mc-text--center'>
@@ -297,13 +297,22 @@ class ModalExample extends Component {
                           <h6 className='mc-text-h2 mc-text--uppercase mc-text--center'>
                             Super Long Modal
                           </h6>
-                          <p className='mc-opacity--muted mc-text--center'>
+                          <p
+                            className='mc-opacity--muted mc-text--center'
+                            style={{ height: '400px' }}
+                          >
                             Seems to stretch...
                           </p>
-                          <p className='mc-opacity--muted mc-text--center'>
+                          <p
+                            className='mc-opacity--muted mc-text--center'
+                            style={{ height: '400px' }}
+                          >
                             Forever...
                           </p>
-                          <p className='mc-opacity--muted mc-text--center'>
+                          <p
+                            className='mc-opacity--muted mc-text--center'
+                            style={{ height: '1000px' }}
+                          >
                             ...
                           </p>
                         </div>
@@ -312,10 +321,10 @@ class ModalExample extends Component {
                   </ModalContent>
                 </Modal>
               </CodeExample>
-              <div style={{ height: '1500px' }} />
             </div>
           </div>
         </DocSection>
+        <div style={{ height: '2000px' }} />
       </div>
     )
   }

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -94,8 +94,8 @@
     }
   }
 
-  &__body--open,
   &__html--open {
     overflow: hidden;
+    body { overflow: hidden; }
   }
 }

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -45,7 +45,7 @@
     // vertically centered stuffs
     display: flex;
     align-items: center;
-    min-height: 95vh;
+    min-height: calc(100vh - 3.5rem);
   }
 
   &__content {

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -32,6 +32,46 @@
   width: 100%;
   height: 100%;
   z-index: $mc-zindex-modal-backdrop;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  // Shell div to position the modal with margin
+  &__viewport {
+    position: relative;
+    width: auto;
+    margin: 1.75rem 0;
+    z-index: $mc-zindex-modal-backdrop;
+
+    // vertically centered stuffs
+    display: flex;
+    align-items: center;
+    min-height: 95vh;
+  }
+
+  &__content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+    width: 100%;
+    outline: 0;
+
+    &:focus {
+      outline: none;
+    }
+
+    .mc-modal--large & {
+      max-width: 888px;
+    }
+
+    .mc-modal--medium & {
+      max-width: 530px;
+    }
+
+    .mc-modal--small & {
+      max-width: 336px;
+    }
+  }
 
   &__close {
     position: absolute;
@@ -54,35 +94,8 @@
     }
   }
 
-  &__content-container {
-    flex: 1;
-    margin: auto;
-    z-index: $mc-zindex-modal;
-  }
-
-  &__content {
-    position: relative;
-    margin: 0 auto;
-    width: 100%;
-
-    &:focus {
-      outline: none;
-    }
-
-    .mc-modal--large & {
-      max-width: 888px;
-    }
-
-    .mc-modal--medium & {
-      max-width: 530px;
-    }
-
-    .mc-modal--small & {
-      max-width: 336px;
-    }
-  }
-
-  &__body--open {
+  &__body--open,
+  &__html--open {
     overflow: hidden;
   }
 }

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -83,9 +83,6 @@
   }
 
   &__body--open {
-    position: fixed;
     overflow: hidden;
-    height: 100vh;
-    width: 100vw;
   }
 }


### PR DESCRIPTION
## Overview
Refactoring Modal component to simplify the containers, make them a little more legible, and to clean up the body anti-scrolling and long, scrolling modals.

## Risks
Low - impacts MOST modals in mc (there are some plain-old bootstrap modals still)

## Changes
no intended behavioral differences, except contents are no longer cutoff

## Issue
https://github.com/yankaindustries/mc-components/issues/628

## Breaking change?
backwards compatible