### PR TITLE
Adding overlay type of solid for TileOverlay

### DIFF
--- a/src/components/TileOverlay/index.js
+++ b/src/components/TileOverlay/index.js
@@ -13,6 +13,7 @@ export default class TileOverlay extends PureComponent {
       'gradient-bottom',
       'gradient-left',
       'spotlight',
+      'solid',
     ]),
   }
 

--- a/src/components/TileOverlay/index.stories.js
+++ b/src/components/TileOverlay/index.stories.js
@@ -26,7 +26,7 @@ storiesOf('Components|Tiles/TileOverlay', module)
           type='String'
         >
           <div className='row'>
-            <div className='col-4'>
+            <div className='col-3'>
               <Tile>
                 <Placeholder>
                   gradient-bottom
@@ -35,7 +35,7 @@ storiesOf('Components|Tiles/TileOverlay', module)
               </Tile>
             </div>
 
-            <div className='col-4'>
+            <div className='col-3'>
               <Tile>
                 <Placeholder>
                   gradient-left
@@ -44,12 +44,21 @@ storiesOf('Components|Tiles/TileOverlay', module)
               </Tile>
             </div>
 
-            <div className='col-4'>
+            <div className='col-3'>
               <Tile>
                 <Placeholder>
                   spotlight
                 </Placeholder>
                 <TileOverlay type='spotlight' />
+              </Tile>
+            </div>
+
+            <div className='col-3'>
+              <Tile>
+                <Placeholder>
+                  solid
+                </Placeholder>
+                <TileOverlay type='solid' />
               </Tile>
             </div>
           </div>

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -157,6 +157,10 @@
         rgba($mc-color-dark, 0) 10%
       );
   }
+
+  &--solid {
+    background: rgba(0, 0, 0, 0.8);
+  }
 }
 
 .mc-tile-caption {


### PR DESCRIPTION
## Overview
While building out a feature:
![image](https://user-images.githubusercontent.com/505670/69469301-ef2f1980-0d44-11ea-9676-848d1f88d507.png)

I noticed a gap in our ability to deliver the UI in question.  This PR adds a new overlay type of "solid" adding to our gradient and spotlight options.

## Risks
None, new prop type

## Changes
Adds new prop for `TileOverlay`

## Issue
N/A

## Breaking change?
Backwards Compatible
