### PR TITLE
Updating height of dropdown to 75vh

### DIFF
--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -74,7 +74,7 @@
       @media (min-width: $mc-bp-sm) {
         width: auto;
         max-width: 400px;
-        max-height: 50vh;
+        max-height: 75vh;
 
         border: 1px solid var(--mc-theme-dropdown-border);
         border-radius: $default-radius;


### PR DESCRIPTION
## Overview
Update dropdown height from 50vh to 75vh

## Risks
Low

## Changes
Height of dropdown changes from 50 > 70vh

## Issue
https://github.com/yankaindustries/mc-components/issues/635

## Breaking change?
Potential issues with overflowing height off edge of screen, but acceptable to regress so "Non Breaking Change"
