### PR TITLE
VideoPlayer - Autoplay Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "1.12.3",
+  "version": "1.12.2",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "1.12.3-0",
+  "version": "1.12.3-1",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "1.12.3-1",
+  "version": "1.12.3-2",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "1.12.2-0",
+  "version": "1.12.3-0",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "1.12.3-2",
+  "version": "1.12.3",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "1.12.1",
+  "version": "1.12.2-0",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mc-components",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": "Masterclass <engineering@masterclass.com>",
   "homepage": "https://github.com/yankaindustries/mc-components",
   "license": "MIT",

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -414,6 +414,13 @@ export default class VideoPlayer extends PureComponent {
       hasControls,
       isMuted,
       isLooped,
+
+      // Pull out all of the props we don't want to pass along to the <video />
+      onPlayerReady,
+      onVideoReady,
+      onEnd,
+      onTimeChange,
+      onSeek,
       ...restProps
     } = this.props
 

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -133,7 +133,7 @@ export default class VideoPlayer extends PureComponent {
   }
 
   handlePlayerReady = () => {
-    const { onPlayerReady } = this.props
+    const { hasAutoplay, isMuted, onPlayerReady } = this.props
 
     // eslint-disable-next-line
     this.setState({ videoRoot: this.video.el_ })
@@ -145,11 +145,11 @@ export default class VideoPlayer extends PureComponent {
     this.video.on('fullscreenchange', this.handleFullscreenChange)
     this.video.on('loadedmetadata', this.handleReady)
 
-    if (this.props.isMuted) {
+    if (isMuted) {
       this.video.muted(true)
     }
 
-    if (this.props.hasAutoplay) {
+    if (hasAutoplay) {
       this.video.play()
     }
 

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -145,6 +145,14 @@ export default class VideoPlayer extends PureComponent {
     this.video.on('fullscreenchange', this.handleFullscreenChange)
     this.video.on('loadedmetadata', this.handleReady)
 
+    if (this.props.isMuted) {
+      this.video.muted(true)
+    }
+
+    if (this.props.hasAutoplay) {
+      this.video.play()
+    }
+
     if (onPlayerReady) {
       onPlayerReady(this.video)
     }
@@ -405,6 +413,7 @@ export default class VideoPlayer extends PureComponent {
       hasAutoplay,
       hasControls,
       isMuted,
+      isLooped,
       ...restProps
     } = this.props
 
@@ -428,8 +437,6 @@ export default class VideoPlayer extends PureComponent {
       [`vjs-fill-${fill}`]: !!fill,
     })
 
-    console.log(restProps)
-
     return (
       <div
         className={containerClasses}
@@ -447,6 +454,7 @@ export default class VideoPlayer extends PureComponent {
             autoPlay={hasAutoplay}
             controls={hasControls}
             muted={isMuted}
+            loop={isLooped}
             {...restProps}
           />
         </div>

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -428,6 +428,8 @@ export default class VideoPlayer extends PureComponent {
       [`vjs-fill-${fill}`]: !!fill,
     })
 
+    console.log(restProps)
+
     return (
       <div
         className={containerClasses}

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -21,8 +21,6 @@ const FILL_NONE = null
 
 const CC_HIDDEN = 'hidden'
 
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
-
 
 export default class VideoPlayer extends PureComponent {
   static propTypes = {
@@ -192,18 +190,10 @@ export default class VideoPlayer extends PureComponent {
   }
 
   handleReady = () => {
-    const {
-      hasAutoplay,
-      isMuted,
-      onVideoReady,
-    } = this.props
+    const { onVideoReady } = this.props
 
     this.checkBuffers()
     this.turnOffCaptions()
-
-    if (hasAutoplay && (!isSafari || isMuted)) {
-      this.video.play()
-    }
 
     if (onVideoReady) {
       onVideoReady(this.video)
@@ -412,6 +402,7 @@ export default class VideoPlayer extends PureComponent {
       playerId,
       videoId,
 
+      hasAutoplay,
       hasControls,
       isMuted,
       ...restProps
@@ -451,8 +442,9 @@ export default class VideoPlayer extends PureComponent {
             data-account={accountId}
             data-player-id={playerId}
             data-video-id={videoId}
-            muted={isMuted}
+            autoPlay={hasAutoplay}
             controls={hasControls}
+            muted={isMuted}
             {...restProps}
           />
         </div>

--- a/src/components/VideoPlayer/index.stories.js
+++ b/src/components/VideoPlayer/index.stories.js
@@ -208,7 +208,10 @@ storiesOf('Components|VideoPlayer', module)
         <PropExample
           name='hasAutoplay'
           type='boolean'
-          description='Automatically plays the video when ready.'
+          description='
+            Automatically plays the video when ready. NOTE: this will not work
+            alone on mobile browsers. Must be accompanied by `isMuted`
+          '
         >
           <div className='row'>
             <div className='col-lg-4'>

--- a/src/components/VideoPlayerPortalScreen/index.js
+++ b/src/components/VideoPlayerPortalScreen/index.js
@@ -1,6 +1,6 @@
 import { Component } from 'react'
 import ReactDOM from 'react-dom'
-import { node } from 'prop-types'
+import { object } from 'prop-types'
 
 import { PROP_TYPE_CHILDREN } from '../constants'
 
@@ -8,7 +8,7 @@ import { PROP_TYPE_CHILDREN } from '../constants'
 export default class VideoPlayerPortalScreen extends Component {
   static propTypes = {
     children: PROP_TYPE_CHILDREN,
-    videoRoot: node,
+    videoRoot: object,
   }
 
   render () {

--- a/src/components/VideoPlayerPortalScreen/index.js
+++ b/src/components/VideoPlayerPortalScreen/index.js
@@ -1,6 +1,6 @@
 import { Component } from 'react'
 import ReactDOM from 'react-dom'
-import { instanceOf } from 'prop-types'
+import { node } from 'prop-types'
 
 import { PROP_TYPE_CHILDREN } from '../constants'
 
@@ -8,7 +8,7 @@ import { PROP_TYPE_CHILDREN } from '../constants'
 export default class VideoPlayerPortalScreen extends Component {
   static propTypes = {
     children: PROP_TYPE_CHILDREN,
-    videoRoot: instanceOf(Element),
+    videoRoot: node,
   }
 
   render () {

--- a/src/components/VideoPlayerScreen/index.js
+++ b/src/components/VideoPlayerScreen/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { bool, oneOf, instanceOf } from 'prop-types'
+import { bool, oneOf, node } from 'prop-types'
 import cn from 'classnames'
 
 import VideoPlayerPortalScreen from '../VideoPlayerPortalScreen'
@@ -35,7 +35,7 @@ const VideoPlayerScreen = ({
 VideoPlayerScreen.propTypes = {
   children: PROP_TYPE_CHILDREN.isRequired,
   variation: oneOf(['endscreen', 'beforescreen', 'pausescreen']),
-  videoRoot: instanceOf(Element),
+  videoRoot: node,
   isActive: bool,
 }
 

--- a/src/components/VideoPlayerScreen/index.js
+++ b/src/components/VideoPlayerScreen/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { bool, oneOf, node } from 'prop-types'
+import { bool, oneOf, object } from 'prop-types'
 import cn from 'classnames'
 
 import VideoPlayerPortalScreen from '../VideoPlayerPortalScreen'
@@ -35,7 +35,7 @@ const VideoPlayerScreen = ({
 VideoPlayerScreen.propTypes = {
   children: PROP_TYPE_CHILDREN.isRequired,
   variation: oneOf(['endscreen', 'beforescreen', 'pausescreen']),
-  videoRoot: node,
+  videoRoot: object,
   isActive: bool,
 }
 


### PR DESCRIPTION
## Overview
Autoplay for inline videos on mobile wasn't working.  Essentially, muting wasn't working properly, which Mobile Safari requires in order to autoplay.

## Risks
Medium - Affects autoplay for all players

## Changes
n/a


## Breaking change?
Backwards Compatible
