### PR TITLE
Moved Html Class changes from Dropdown to DropdownContentControlled

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "react/jsx-wrap-multilines": 0,
     "react/no-find-dom-node": 0,
     "react/require-default-props": 0,
+    "class-methods-use-this": 0,
   },
   "globals": {
     "window": true,

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -39,11 +39,6 @@ export default class Dropdown extends PureComponent {
     this.renderDropdown()
   }
 
-  componentWillUnmount () {
-    const rootHtml = document.getElementsByTagName('html')[0]
-    rootHtml.classList.remove('mc-dropdown__html--open')
-  }
-
   componentDidUpdate (prevProps) {
     if (prevProps.placement !== this.props.placement) {
       this.renderDropdown()
@@ -51,10 +46,7 @@ export default class Dropdown extends PureComponent {
   }
 
   toggle = (event) => {
-    const {
-      lastTimeStamp,
-      show,
-    } = this.state
+    const { lastTimeStamp } = this.state
 
     if (event.persist) {
       event.persist()
@@ -62,13 +54,6 @@ export default class Dropdown extends PureComponent {
 
     if (event.timeStamp === lastTimeStamp) {
       return
-    }
-
-    const rootHtml = document.getElementsByTagName('html')[0]
-    if (!show) {
-      rootHtml.classList.add('mc-dropdown__html--open')
-    } else {
-      rootHtml.classList.remove('mc-dropdown__html--open')
     }
 
     this.setState(prevState => ({

--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -40,7 +40,8 @@ export default class Dropdown extends PureComponent {
   }
 
   componentWillUnmount () {
-    document.body.classList.remove('mc-dropdown__body--open')
+    const rootHtml = document.getElementsByTagName('html')[0]
+    rootHtml.classList.remove('mc-dropdown__html--open')
   }
 
   componentDidUpdate (prevProps) {

--- a/src/components/DropdownContent/index.js
+++ b/src/components/DropdownContent/index.js
@@ -8,10 +8,9 @@ export default class DropdownContent extends PureComponent {
   render () {
     return (
       <Consumer>
-        {({ show, toggle }) =>
+        {({ show }) =>
           <DropdownContentControlled
             show={show}
-            onClose={toggle}
             {...this.props}
           />
         }

--- a/src/components/DropdownContent/index.js
+++ b/src/components/DropdownContent/index.js
@@ -8,9 +8,10 @@ export default class DropdownContent extends PureComponent {
   render () {
     return (
       <Consumer>
-        {({ show }) =>
+        {({ show, toggle }) =>
           <DropdownContentControlled
             show={show}
+            onClose={toggle}
             {...this.props}
           />
         }

--- a/src/components/DropdownContentControlled/index.js
+++ b/src/components/DropdownContentControlled/index.js
@@ -10,15 +10,6 @@ import Icon from '../Icons'
 import { PROP_TYPE_CHILDREN } from '../constants'
 import { getClosest } from '../helpers'
 
-const toggleHtmlClassName = function (isShown) {
-  const rootHtml = document.getElementsByTagName('html')[0]
-  if (!isShown) {
-    rootHtml.classList.remove('mc-dropdown__html--open')
-  } else {
-    rootHtml.classList.add('mc-dropdown__html--open')
-  }
-}
-
 export default class DropdownContentControlled extends PureComponent {
   static propTypes = {
     children: PROP_TYPE_CHILDREN,
@@ -48,15 +39,24 @@ export default class DropdownContentControlled extends PureComponent {
 
     this.setState({ checkedInvert: true })
 
-    toggleHtmlClassName(this.props.show)
+    this.toggleHtmlClassName(this.props.show)
   }
 
   componentDidUpdate () {
-    toggleHtmlClassName(this.props.show)
+    this.toggleHtmlClassName(this.props.show)
   }
 
   componentWillUnmount () {
-    toggleHtmlClassName(false)
+    this.toggleHtmlClassName(false)
+  }
+
+  toggleHtmlClassName (isShown) {
+    const rootHtml = document.getElementsByTagName('html')[0]
+    if (!isShown) {
+      rootHtml.classList.remove('mc-dropdown__html--open')
+    } else {
+      rootHtml.classList.add('mc-dropdown__html--open')
+    }
   }
 
   handleClose = source => (event) => {

--- a/src/components/DropdownContentControlled/index.js
+++ b/src/components/DropdownContentControlled/index.js
@@ -10,6 +10,14 @@ import Icon from '../Icons'
 import { PROP_TYPE_CHILDREN } from '../constants'
 import { getClosest } from '../helpers'
 
+const toggleHtmlClassName = function (isShown) {
+  const rootHtml = document.getElementsByTagName('html')[0]
+  if (!isShown) {
+    rootHtml.classList.remove('mc-dropdown__html--open')
+  } else {
+    rootHtml.classList.add('mc-dropdown__html--open')
+  }
+}
 
 export default class DropdownContentControlled extends PureComponent {
   static propTypes = {
@@ -39,16 +47,24 @@ export default class DropdownContentControlled extends PureComponent {
     }
 
     this.setState({ checkedInvert: true })
+
+    toggleHtmlClassName(this.props.show)
   }
 
-  handleClose = (toggle, source) => (event) => {
+  componentDidUpdate () {
+    toggleHtmlClassName(this.props.show)
+  }
+
+  componentWillUnmount () {
+    toggleHtmlClassName(false)
+  }
+
+  handleClose = source => (event) => {
     const { show, onClose } = this.props
 
     if (!show) {
       return
     }
-
-    toggle(event)
 
     onClose(source, event)
   }
@@ -78,11 +94,10 @@ export default class DropdownContentControlled extends PureComponent {
           attributes,
           dropdownRef,
           styles,
-          toggle,
         }) =>
           <ClickOutside
             divRef={dropdownRef}
-            onClickOutside={this.handleClose(toggle, 'outside')}
+            onClickOutside={this.handleClose('outside')}
           >
             <div
               className={classes}
@@ -99,7 +114,7 @@ export default class DropdownContentControlled extends PureComponent {
                 <div className='d-block d-sm-none mc-dropdown__close'>
                   <a
                     className='d-inline-block mc-p-2'
-                    onClick={this.handleClose(toggle, 'close')}
+                    onClick={this.handleClose('close')}
                   >
                     <Icon kind='close' className='mc-dropdown__close-icon' />
                   </a>

--- a/src/components/DropdownContentControlled/index.js
+++ b/src/components/DropdownContentControlled/index.js
@@ -41,12 +41,14 @@ export default class DropdownContentControlled extends PureComponent {
     this.setState({ checkedInvert: true })
   }
 
-  handleClose = source => (event) => {
+  handleClose = (toggle, source) => (event) => {
     const { show, onClose } = this.props
 
     if (!show) {
       return
     }
+
+    toggle(event)
 
     onClose(source, event)
   }
@@ -76,10 +78,11 @@ export default class DropdownContentControlled extends PureComponent {
           attributes,
           dropdownRef,
           styles,
+          toggle,
         }) =>
           <ClickOutside
             divRef={dropdownRef}
-            onClickOutside={this.handleClose('outside')}
+            onClickOutside={this.handleClose(toggle, 'outside')}
           >
             <div
               className={classes}
@@ -96,7 +99,7 @@ export default class DropdownContentControlled extends PureComponent {
                 <div className='d-block d-sm-none mc-dropdown__close'>
                   <a
                     className='d-inline-block mc-p-2'
-                    onClick={this.handleClose('close')}
+                    onClick={this.handleClose(toggle, 'close')}
                   >
                     <Icon kind='close' className='mc-dropdown__close-icon' />
                   </a>


### PR DESCRIPTION
## Overview
Moved the html classname addition/removal from Dropdown to DropdownContentControlled, so that the latter would appropriately add the necessary class when shown

## Risks
Low

## Changes
Just moves the addition/removal of the 'mc-dropdown__html--open' class to/from the <HTML> tag when the DropdownContentControlled component is shown and closed

## Issue
<Does this PR fix an existing issue? If so, link to it here>

## Breaking change?
Backwards Compatible