### PR TITLE
Fix alignment for radio and checkboxes

### DIFF
--- a/src/styles/components/forms/_checkbox.scss
+++ b/src/styles/components/forms/_checkbox.scss
@@ -9,7 +9,6 @@
     align-items: center;
     justify-content: center;
     vertical-align: middle;
-    margin-top: -4px; // vertically center box
     width: 20px;
     height: 20px;
     background: var(--mc-theme-checkbox-bg);

--- a/src/styles/components/forms/_radio.scss
+++ b/src/styles/components/forms/_radio.scss
@@ -9,7 +9,7 @@
     align-items: center;
     justify-content: center;
     vertical-align: middle;
-    margin-top: -4px; // vertically center box
+    margin-top: -2px; // vertically center box
     width: 20px;
     height: 20px;
     background: var(--mc-theme-radio-bg);

--- a/src/styles/components/forms/_radio.scss
+++ b/src/styles/components/forms/_radio.scss
@@ -9,7 +9,6 @@
     align-items: center;
     justify-content: center;
     vertical-align: middle;
-    margin-top: -2px; // vertically center box
     width: 20px;
     height: 20px;
     background: var(--mc-theme-radio-bg);


### PR DESCRIPTION
## Overview
As part of a code review, I noticed an override was being set for checkbox button alignment. At some point our values for the radio buttons and checkboxes changed and no longer line up with the text correctly, so this adjusts them to vertically align better again.

Comparison (animated):
![diff](https://user-images.githubusercontent.com/505670/73310396-1a1c6a80-41d9-11ea-9f2d-7d1b2a4d27ae.gif)

## Risks
None

## Changes
Vertically adjusts positioning of radio button

## Issue
Part of: https://github.com/yankaindustries/mc-components/issues/656

## Breaking change?
Backwards Compatible