### PR TITLE
Remove on[Play|Pause|FullscreenChange] from <video> component

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -25,7 +25,7 @@ const CC_HIDDEN = 'hidden'
 export default class VideoPlayer extends PureComponent {
   static propTypes = {
     accountId: PropTypes.string,
-    playerId: PropTypes.string.isRequired,
+    playerId: PropTypes.string,
     videoId: PropTypes.string.isRequired,
 
     endscreenComponent: PropTypes.func,
@@ -418,9 +418,12 @@ export default class VideoPlayer extends PureComponent {
       // Pull out all of the props we don't want to pass along to the <video />
       onPlayerReady,
       onVideoReady,
+      onPlay,
+      onPause,
       onEnd,
       onTimeChange,
       onSeek,
+      onFullscreenChange,
       ...restProps
     } = this.props
 


### PR DESCRIPTION
## Overview
some minor fixes for the onPlay, onPause and onFullscreenChange event props/handlers for the MCC.VideoPlayer component.  Also snuck in the removal of the 'required' flag for the playerId prop.

## Risks
Low - the fore-mentioned handlers were actually getting called twice, inadvertently.  If any of the VideoPlayer implementations were actually depending on this for whatever reason, they may break after 'fixing' this problem

## Changes
Should prevent onPlay, onPause, onFullscreenChange from firing twice

## Issue
N/A

## Breaking change?
should be backwards compatible, except as fore-mentioned in the risks section