### PR TITLE
Fix VideoPlayer Looping

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -493,7 +493,6 @@ export default class VideoPlayer extends PureComponent {
             autoPlay={hasAutoplay}
             controls={hasControls}
             muted={isMuted}
-            loop={isLooped}
             {...restProps}
           />
         </div>


### PR DESCRIPTION
## Overview
Currently, when the VideoPlayer loops playback, it depends on native HTML5 video 'loop' property.  Upon the 2nd iteration of the video, it no longer fires any of the event handlers.  Instead of this approach, we're removing the native loop, and we're relying on the handleEnd method to restart/loop the playback

## Risks
None

## Changes
allows for proper event handling on subsequent playback iterations

## Issue
N/A

## Breaking change?
Backwards Compatible
