### PR TITLE
Omit the pause event if at end of video

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -198,7 +198,8 @@ export default class VideoPlayer extends PureComponent {
 
   handlePause = () => {
     const { onPause } = this.props
-    if (this.video.seeking()) {
+
+    if (this.video.seeking() || this.isAtEndOfVideo()) {
       return
     }
 
@@ -209,6 +210,13 @@ export default class VideoPlayer extends PureComponent {
     if (onPause) {
       onPause(this.video)
     }
+  }
+
+  isAtEndOfVideo = () => {
+    const duration = Math.floor(this.video.duration())
+    const position = Math.floor(this.video.currentTime())
+
+    return duration === position
   }
 
   handleSeeking = () => {


### PR DESCRIPTION
## Overview
BC player LOVES to send pause events... sometimes I feel like it just gets bored (j/k).  It sends pause events when the video completes, so I've added a check to omit that.

## Risks
Low - only risk is if somebody is doing something frisky with the pause events.  I've performed a quick search and found no such thing

## Changes
prevents this from happening at the end of a video:
![image](https://user-images.githubusercontent.com/56046844/75076278-99d5e600-54b4-11ea-8323-95bb672aab3e.png)

## Issue
N/A

## Breaking change?
N/A