### PR TITLE
[WA-131] Removed the backwards scrubbing protection around onTimeChange()

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -381,7 +381,7 @@ export default class VideoPlayer extends PureComponent {
       this.video.on('timeupdate', () => {
         const currentTime = Math.floor(this.video.currentTime())
         const remainingTime = Math.floor(this.video.remainingTime())
-        if (this.currentTime === undefined || this.currentTime != currentTime) {
+        if (this.currentTime === undefined || this.currentTime !== currentTime) {
           this.currentTime = currentTime
           this.props.onTimeChange(currentTime, remainingTime)
         }

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -381,7 +381,8 @@ export default class VideoPlayer extends PureComponent {
       this.video.on('timeupdate', () => {
         const currentTime = Math.floor(this.video.currentTime())
         const remainingTime = Math.floor(this.video.remainingTime())
-        if (this.currentTime === undefined || this.currentTime !== currentTime) {
+        if (this.currentTime === undefined ||
+        this.currentTime !== currentTime) {
           this.currentTime = currentTime
           this.props.onTimeChange(currentTime, remainingTime)
         }

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -381,7 +381,7 @@ export default class VideoPlayer extends PureComponent {
       this.video.on('timeupdate', () => {
         const currentTime = Math.floor(this.video.currentTime())
         const remainingTime = Math.floor(this.video.remainingTime())
-        if (this.currentTime === undefined || this.currentTime < currentTime) {
+        if (this.currentTime === undefined || this.currentTime != currentTime) {
           this.currentTime = currentTime
           this.props.onTimeChange(currentTime, remainingTime)
         }


### PR DESCRIPTION
## Overview
there currently exists protection against backward scrubbing in the MCC.VideoPlayer component.  This is ill-placed in the MCC repo, and is MC-specific.  Therefore it should be in the MC.VideoPlayer component instead, to keep the MCC component more generic.

## Risks
Low

## Changes
Simply removes the protection against backward scrubbing and onTimeChange()

## Issue
N/A

## Breaking change?
Backwards Compatible
