### PR TITLE
Add end prop to ScrollHandler

### DIFF
--- a/src/components/ScrollHandler/index.js
+++ b/src/components/ScrollHandler/index.js
@@ -8,6 +8,7 @@ import { renderChildren } from '../helpers'
 export default class ScrollHandler extends PureComponent {
   static propTypes = {
     to: PropTypes.number,
+    end: PropTypes.number,
     children: PROP_TYPE_CHILDREN.isRequired,
   }
 
@@ -31,9 +32,13 @@ export default class ScrollHandler extends PureComponent {
 
   checkIfSufficientlyScrolled = () => {
     const scrollY = window.pageYOffset || document.documentElement.scrollTop
+    const endY = this.props.end
+
+    let scrolled = scrollY > this.props.to
+    if (endY) scrolled = scrolled && (scrollY < endY)
 
     this.setState({
-      scrolled: scrollY > this.props.to,
+      scrolled,
     })
   }
 


### PR DESCRIPTION
## Overview
Add `end` prop to `ScrollHandler` component. The idea is add other point where if user scrolls down that given point `scrolled` turns `false`.

If no `end` prop is passed to `ScrollHandler` the component acts as always.

## Risks
Low

## Breaking change?
Backwards Compatible

![scroll](https://user-images.githubusercontent.com/18334634/75919863-14035480-5e3d-11ea-8bbf-275ac4555d72.gif)

