### PR TITLE
Fix checkbox/radio double onChange

### DIFF
--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -48,7 +48,6 @@ export default class Checkbox extends PureComponent {
         className={classes}
         id={`${name}-label`}
         htmlFor={name}
-        onClick={this.handleClick}
       >
         <div>
           <span
@@ -63,6 +62,7 @@ export default class Checkbox extends PureComponent {
             className='mc-input-checkbox__realbox'
             value={checked}
             disabled={disabled}
+            onClick={this.handleClick}
           />
         </div>
         <span>

--- a/src/components/Radio/index.js
+++ b/src/components/Radio/index.js
@@ -49,7 +49,6 @@ export default class Radio extends PureComponent {
         className={classes}
         id={`${option}-label`}
         htmlFor={name}
-        onClick={this.handleClick}
       >
         <div>
           <span
@@ -64,6 +63,7 @@ export default class Radio extends PureComponent {
             className='mc-input-radio__realbox'
             value={option}
             disabled={disabled}
+            onClick={this.handleClick}
           />
         </div>
         <span>


### PR DESCRIPTION
## Overview
Checkbox and Radio components were double firing their `onChange` callback when clicked.  This is because clicking the label also triggers a click on the child input.  By moving the `onClick` handler to the input, we avoid double firing said handler.

## Risks
None

## Issue
https://github.com/yankaindustries/mc-components/issues/652

## Breaking change?
Backwards Compatible
