### PR TITLE
Adding opacity values to documentation

### DIFF
--- a/src/foundation/utilities/opacity.stories.js
+++ b/src/foundation/utilities/opacity.stories.js
@@ -13,7 +13,7 @@ const Opacity = () =>
       description='The opacity utility can modify the opacity of any dom element.'
     />
 
-    <DocSection title='Color'>
+    <DocSection title='Opacities'>
       <div className='row'>
         <div className='col-md-4'>
           <PropExample name='.mc-opacity--hinted'>

--- a/src/foundation/utilities/opacity.stories.js
+++ b/src/foundation/utilities/opacity.stories.js
@@ -18,7 +18,7 @@ const Opacity = () =>
         <div className='col-md-4'>
           <PropExample name='.mc-opacity--hinted'>
             <h6 className='mc-text-h5 mc-opacity--hinted'>
-              The quick brown fox jumped over the lazy dog.
+              The quick brown fox jumped over the lazy dog (80%).
             </h6>
           </PropExample>
         </div>
@@ -26,7 +26,7 @@ const Opacity = () =>
         <div className='col-md-4'>
           <PropExample name='.mc-opacity--muted'>
             <h6 className='mc-text-h5 mc-opacity--muted'>
-              The quick brown fox jumped over the lazy dog.
+              The quick brown fox jumped over the lazy dog (60%).
             </h6>
           </PropExample>
         </div>
@@ -34,7 +34,7 @@ const Opacity = () =>
         <div className='col-md-4'>
           <PropExample name='.mc-opacity--silenced'>
             <h6 className='mc-text-h5 mc-opacity--silenced'>
-              The quick brown fox jumped over the lazy dog.
+              The quick brown fox jumped over the lazy dog (30%).
             </h6>
           </PropExample>
         </div>


### PR DESCRIPTION
## Overview
Adding values for opacity helpers to documentation so that you don't have to inspect to get the number value.

## Risks
None

## Issue
https://github.com/yankaindustries/mc-components/issues/634

## Breaking change?
Backwards Compatible
