### PR TITLE
Helper Class - `mc-clickable`

### DIFF
--- a/src/styles/helpers/_helpers.scss
+++ b/src/styles/helpers/_helpers.scss
@@ -5,3 +5,4 @@
 @import "spacing-margin";
 @import "spacing-padding";
 @import "corners";
+@import "interactive";

--- a/src/styles/helpers/_interactive.scss
+++ b/src/styles/helpers/_interactive.scss
@@ -1,0 +1,3 @@
+.mc-clickable {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Overview
A lot of custom CSS is simply setting a component to appear clickable to the user with a cursor pointer.  Instead of having to write custom CSS for this, here's a helper class.

## Risks
None

## Changes
None

## Issue
https://github.com/yankaindustries/mc-components/issues/621

## Breaking change?
Backwards Compatible
