### PR TITLE
Background - replacing JS positioning logic with CSS

### DIFF
--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -62,29 +62,8 @@ export default class Background extends PureComponent {
     loaded: false,
   }
 
-  componentWillUnmount () {
-    if (this.props.element) {
-      window.removeEventListener('resize', this.setSizeBy)
-    }
-  }
-
   onLoad = () => {
-    this.setSizeBy()
     this.setState({ loaded: true })
-    window.addEventListener('resize', this.setSizeBy.bind(this))
-  }
-
-  setSizeBy = () => {
-    // TODO see why sometimes the refs aren't populated, remove this check
-    if (this.container.current && this.background.current) {
-      const containerRatio =
-        this.container.current.offsetWidth / this.container.current.offsetHeight
-      const backgroundRatio =
-        this.background.current.width / this.background.current.height
-      const sizeBy = containerRatio > backgroundRatio ? 'width' : 'height'
-
-      this.setState({ sizeBy })
-    }
   }
 
   render () {
@@ -100,7 +79,6 @@ export default class Background extends PureComponent {
 
     const {
       loaded,
-      sizeBy,
     } = this.state
 
     const [x, y] = position.split(' ')
@@ -114,7 +92,6 @@ export default class Background extends PureComponent {
       [`mc-background--position-x-${x}`]: element,
       [`mc-background--position-y-${y}`]: element,
       [`mc-background--size-${size}`]: element,
-      [`mc-background--size-${size}-${sizeBy}`]: element,
     })
 
     return (
@@ -127,6 +104,10 @@ export default class Background extends PureComponent {
             className: 'mc-background__background',
             ref: this.background,
             onLoad: this.onLoad,
+            style: {
+              objectFit: size,
+              objectPosition: position,
+            },
           })}
         </div>
         <div className='mc-background__content-container'>

--- a/src/components/Background/index.stories.js
+++ b/src/components/Background/index.stories.js
@@ -74,7 +74,7 @@ storiesOf('Components|Background', module)
               <Background
                 element={<img src={abstractBackground} />}
                 fit='content'
-                position='center top'
+                position='center center'
                 size='cover'
               >
                 <br />

--- a/src/styles/components/_background.scss
+++ b/src/styles/components/_background.scss
@@ -103,28 +103,19 @@
     }
   }
 
-  &--size-cover-width {
+  &--size-cover {
     .mc-background__background {
+      object-fit: cover;
       width: 100%;
-    }
-  }
-
-  &--size-cover-height {
-    .mc-background__background {
-      position: absolute;
       height: 100%;
     }
   }
 
-  &--size-contain-width {
+  &--size-contain {
     .mc-background__background {
-      max-height: 100%;
-    }
-  }
-
-  &--size-contain-height {
-    .mc-background__background {
+      object-fit: contain;
       max-width: 100%;
+      max-height: 100%;
     }
   }
 


### PR DESCRIPTION
## Overview
The Background component used JS to decide how to place the image.  This is easily doable now with CSS, so this PR replaces that logic.

## Risks
Low - tested all permutations I could think of, potential that one is missed.

## Changes
No visible changes

## Issue
https://github.com/yankaindustries/mc-components/issues/611

## Breaking change?
Backwards Compatible
