### PR TITLE
killing extra garbage in aspect-ratio mixin

### DIFF
--- a/src/styles/base/mixins/_ratios.scss
+++ b/src/styles/base/mixins/_ratios.scss
@@ -10,42 +10,4 @@
     padding-top: ($height / $width) * 100%;
     content: "";
   }
-
-  // Todo - Make sure this is deprecated and use fill instead
-
-  > .background {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 1;
-    background-repeat: cover;
-    background-size: cover;
-  }
-
-  .fill {
-    position: absolute;
-    top: 0;
-    left: 0;
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-
-    &:after {
-      position: relative;
-      width: 100%;
-      height: 100%;
-      content: " ";
-    }
-  }
-
-  .content {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 2;
-  }
 }


### PR DESCRIPTION
## Overview
There's some old code associated to tiles / aspect ratios.  Kill it ded.

## Risks
Low - looked for anywhere that was implementing `aspect-ratio` mixin to see if it relied on the old classes `.content` and `.background`.  There was a single case, and it was not.

## Changes
None

## Issue
https://github.com/yankaindustries/mc-components/issues/358

## Breaking change?
Backwards Compatible
