### PR TITLE
Adding catch for blocked autoplay

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -165,7 +165,10 @@ export default class VideoPlayer extends PureComponent {
     }
 
     if (hasAutoplay) {
-      this.video.play()
+      const promise = this.video.play()
+      if (promise !== undefined) {
+        promise.catch(() => {})
+      }
     }
 
     this.checkBuffers()
@@ -419,7 +422,10 @@ export default class VideoPlayer extends PureComponent {
           }
           this.video.catalog.load(video)
           if (hasAutoplay) {
-            this.video.play()
+            const promise = this.video.play()
+            if (promise !== undefined) {
+              promise.catch(() => {})
+            }
           }
         },
       )


### PR DESCRIPTION
## Overview
there was an issue discovered where autoplay was throwing an exception.  This is as designed per browser autoplay policies

![image](https://user-images.githubusercontent.com/56046844/76110826-10ceac80-5f94-11ea-966b-4d88f2a80341.png)

Google AutoPlay Policy Changes:
https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#new-behaviors

## Risks
None

## Changes
Before:
![image](https://user-images.githubusercontent.com/56046844/76087621-6347a300-5f6b-11ea-8986-630f4233653c.png)

After:
![image](https://user-images.githubusercontent.com/56046844/76087827-c6393a00-5f6b-11ea-83a4-666a4fb57f7a.png)

## Issue
N/A

## Breaking change?
Backwards Compatible
