### PR TITLE
improving implementation of tile overlay colors

### DIFF
--- a/src/components/TileOverlay/index.js
+++ b/src/components/TileOverlay/index.js
@@ -19,28 +19,22 @@ export default class TileOverlay extends PureComponent {
 
   static defaultProps = {
     type: 'gradient-bottom',
-    color: '0, 0, 0',
+    color: null,
   }
 
-  render () {
-    const {
-      children,
-      className,
-      color,
-      type,
-    } = this.props
+  getStyles = () => {
+    const { color, type } = this.props
 
-    const classes = [
-      'mc-tile__component',
-      'mc-tile-overlay',
-      `mc-tile-overlay--${type}`,
-      className || '',
-    ].join(' ')
+    if (!color) return {}
 
-    let styles = {}
+    if (type === 'solid') {
+      return {
+        background: `rgba(${color}, 0.8)`,
+      }
+    }
 
     if (type === 'gradient-bottom') {
-      styles = {
+      return {
         background: `
           linear-gradient(
             to top,
@@ -53,7 +47,7 @@ export default class TileOverlay extends PureComponent {
     }
 
     if (type === 'gradient-left') {
-      styles = {
+      return {
         background: `
           linear-gradient(
             to right,
@@ -64,6 +58,47 @@ export default class TileOverlay extends PureComponent {
         `,
       }
     }
+
+    if (type === 'spotlight') {
+      return {
+        background: `
+          radial-gradient(
+            farthest-side at center top,
+            rgba(${color}, 0) 33%,
+            rgba(${color}, 1) 100%
+          ),
+          linear-gradient(
+            to right,
+            rgba(${color}, 1) 0%,
+            rgba(${color}, 0) 10%
+          ),
+          linear-gradient(
+            to left,
+            rgba(${color}, 1) 0%,
+            rgba(${color}, 0) 10%
+          );
+        `,
+      }
+    }
+
+    return {}
+  }
+
+  render () {
+    const {
+      children,
+      className,
+      type,
+    } = this.props
+
+    const classes = [
+      'mc-tile__component',
+      'mc-tile-overlay',
+      `mc-tile-overlay--${type}`,
+      className || '',
+    ].join(' ')
+
+    const styles = this.getStyles()
 
     return (
       <div className={classes} style={styles}>

--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -116,6 +116,8 @@
 }
 
 .mc-tile-overlay {
+  $mc-tile-overlay-color: $mc-color-gray-100;
+
   transform: scale(1.01);
   pointer-events: none;
 
@@ -123,9 +125,9 @@
     background:
       linear-gradient(
         to top,
-        rgba($mc-color-dark, 1) 0,
-        rgba($mc-color-dark, 0.6) 25%,
-        rgba($mc-color-dark, 0) 45%
+        rgba($mc-tile-overlay-color, 1) 0,
+        rgba($mc-tile-overlay-color, 0.6) 25%,
+        rgba($mc-tile-overlay-color, 0) 45%
       ) center no-repeat;
   }
 
@@ -133,9 +135,9 @@
     background:
       linear-gradient(
         to right,
-        rgba($mc-color-dark, 1) 0,
-        rgba($mc-color-dark, 0.6) 25%,
-        rgba($mc-color-dark, 0) 45%
+        rgba($mc-tile-overlay-color, 1) 0,
+        rgba($mc-tile-overlay-color, 0.6) 25%,
+        rgba($mc-tile-overlay-color, 0) 45%
       ) center no-repeat;
   }
 
@@ -143,23 +145,23 @@
     background:
       radial-gradient(
         farthest-side at center top,
-        rgba($mc-color-dark, 0) 33%,
-        rgba($mc-color-dark, 1) 100%
+        rgba($mc-color-background, 0) 33%,
+        rgba($mc-color-background, 1) 100%
       ),
       linear-gradient(
         to right,
-        rgba($mc-color-dark, 1) 0%,
-        rgba($mc-color-dark, 0) 10%
+        rgba($mc-color-background, 1) 0%,
+        rgba($mc-color-background, 0) 10%
       ),
       linear-gradient(
         to left,
-        rgba($mc-color-dark, 1) 0%,
-        rgba($mc-color-dark, 0) 10%
+        rgba($mc-color-background, 1) 0%,
+        rgba($mc-color-background, 0) 10%
       );
   }
 
   &--solid {
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba($mc-tile-overlay-color, 0.8);
   }
 }
 


### PR DESCRIPTION
## Overview
Sets default color for TileOverlay to be `$mc-color-gray-100` (except `spotlight` which is meant to fade the content into the background), and adds color overrides for all overlay types, not just gradients.



## Risks
Low - all tiles that use default color will now switch to the dark gray overlay.  This should, however, be fine

## Changes
![image](https://user-images.githubusercontent.com/249444/76477260-fba5b380-63c1-11ea-8455-88ef9fdba954.png)

## Issue
<Does this PR fix an existing issue? If so, link to it here>

## Breaking change?
Backwards Compatible
