### PR TITLE
getting rid of video fill for fullscreen

### DIFF
--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -15,24 +15,27 @@ $mc-video-progress-height: 0.8rem !default;
   }
 
   &__video {
-    font-family: inherit;
     position: absolute;
     left: 50%;
     top: 50%;
     width: 100%;
     height: 100%;
     transform: translate(-50%, -50%);
-    // Allow overflow to fix "off by one" pixel calculation
     overflow: visible;
+    font-family: inherit;
 
-    &.vjs-fill-width {
-      width: 100%;
-      height: auto;
-    }
+    .video-js:not(.vjs-fullscreen) & {
 
-    &.vjs-fill-height {
-      height: 100%;
-      width: auto;
+
+      &.vjs-fill-width {
+        width: 100%;
+        height: auto;
+      }
+
+      &.vjs-fill-height {
+        height: 100%;
+        width: auto;
+      }
     }
   }
 


### PR DESCRIPTION
## Overview
Videos on some devices fullscreen were cutting off necessary content (because the screens themselves are not perfectly 16x9.  This fixes that by removing the "fill" functionality when in fullscreen.

## Risks
None


## Issue
https://github.com/yankaindustries/mc-components/issues/598

## Breaking change?
Backwards Compatible
