### PR TITLE
Fix Tooltip to update anchor on toggle

### DIFF
--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -81,6 +81,7 @@ export default class Tooltip extends PureComponent {
   }
 
   toggle = () => {
+    this.tooltip.update()
     this.setState(prevState => ({
       show: !prevState.show,
     }))


### PR DESCRIPTION
## Overview
<General description>
<img width="574" alt="Screen Shot 2020-03-16 at 12 54 06 PM" src="https://user-images.githubusercontent.com/8651130/76795951-9d911b80-6787-11ea-96f2-dbd07cf7320c.png">
Tool tip creates the anchor before assets render so going to call update on toggle

## Risks
<What's the risk level of merging this in? | None / Low / Medium / High>

## Changes
<How does this PR affect existing components? Please show screenshots or GIFs>
<img width="703" alt="Screen Shot 2020-03-16 at 12 55 21 PM" src="https://user-images.githubusercontent.com/8651130/76795986-b6013600-6787-11ea-9435-e44d7d61816d.png">


## Issue
<Does this PR fix an existing issue? If so, link to it here>

## Breaking change?
<Is this a breaking change, or is it backwards compatible? | *BREAKING* / Backwards Compatible>
