### PR TITLE
remove scale for tile overlay

### DIFF
--- a/src/styles/components/_tile.scss
+++ b/src/styles/components/_tile.scss
@@ -118,7 +118,6 @@
 .mc-tile-overlay {
   $mc-tile-overlay-color: $mc-color-gray-100;
 
-  transform: scale(1.01);
   pointer-events: none;
 
   &--gradient-bottom {


### PR DESCRIPTION
## Overview
Removing scale responsible for overcompensating for off sub-pixel rendering.  That has been fixed, so we are removing the scaling.

## Risks
None - minimal UI update

## Changes
![image](https://user-images.githubusercontent.com/249444/77020941-919d8900-6942-11ea-9be9-8260730d34c9.png)


## Issue
https://github.com/yankaindustries/mc-components/issues/297

## Breaking change?
Backwards Compatible
