### PR TITLE
Play if hasAutoplay changes

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -97,7 +97,8 @@ export default class VideoPlayer extends PureComponent {
   }
 
   componentDidUpdate (prevProps) {
-    if (this.props.videoId !== prevProps.videoId) {
+    if (this.props.videoId !== prevProps.videoId
+      || this.props.hasAutoplay !== prevProps.hasAutoplay) {
       this.replaceWith(this.props.videoId)
     }
   }


### PR DESCRIPTION
## Overview
Play video when hasAutoplay changes.

## Risks
Checked with @jstnjns on Mastercalss main repo and didn't found any hasAutoplay dynamic props that this would affect, except for `browse-trailers` page (that we will have to check) and the feature I'm working on that inspires the change.

## Changes
I'm productizing `home_page_vide_player_v1` and as a design requirement I was asked to play video when users click on category set by default. Since the video for default category is placed on first component render, click on it doesn't trigger video to play since videoId doesn't change.

I try to change dynamically `hasAutoplay` prop but still wasn't able to get video to play.

Without `hasAutoplay` reacting to changes:

![cldlutCWIX](https://user-images.githubusercontent.com/7109567/77793906-b59b5180-7049-11ea-95ec-ba502d6b6328.gif)

With `hasAutoplay` reacting to changes:

![R1Q7CEyXS9](https://user-images.githubusercontent.com/7109567/77794465-b41e5900-704a-11ea-9ce1-f8b368b135cc.gif)

## Issue
It's a more elegant solution that getting video instance from Masterclass main repo to play video, or duplicate VideoPlayer components.

## Breaking change?
This feature isn't being used on the code yet, so this change shouldn't affect. I checked `browser-trailers` page and seems to be working fine.
