### PR TITLE
New Color Prop for Carousels with Peek

### DIFF
--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -76,6 +76,7 @@ export default class Carousel extends PureComponent {
     sliderRef: PropTypes.func,
     transition: PropTypes.string,
     variableWidth: PropTypes.bool,
+    color: PropTypes.string,
   }
 
   static defaultProps = {
@@ -91,6 +92,7 @@ export default class Carousel extends PureComponent {
     showCount: 3,
     transition: TRANSITION_SLIDE,
     variableWidth: false,
+    color: '0, 0, 0',
   }
 
   arrowContainerRef = React.createRef()
@@ -149,6 +151,7 @@ export default class Carousel extends PureComponent {
       showCount,
       transition,
       variableWidth,
+      color,
       ...restProps
     } = this.props
 
@@ -166,6 +169,27 @@ export default class Carousel extends PureComponent {
       [className]: className,
       'mc-carousel__slider': true,
     })
+
+    let peekStyles
+    if (peek) {
+      peekStyles = {
+        position: 'absolute',
+        right: 0,
+        top: 0,
+        width: '120px',
+        height: '100%',
+        background: `
+          linear-gradient(
+            to left,
+            rgba(${color}, 1) 0,
+            rgba(${color}, 0) 100%
+          ) center no-repeat
+        `,
+        zIndex: 1,
+        pointerEvents: 'none',
+      }
+      console.log('peekStyles: ', peekStyles)
+    }
 
     const arrows = controls
       ? {
@@ -220,6 +244,7 @@ export default class Carousel extends PureComponent {
                 {children}
               </Slider>
             </div>
+            {peek && (<div style={peekStyles}></div>)}
 
             <div
               className='mc-carousel__arrow-container'

--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -188,7 +188,6 @@ export default class Carousel extends PureComponent {
         zIndex: 1,
         pointerEvents: 'none',
       }
-      console.log('peekStyles: ', peekStyles)
     }
 
     const arrows = controls

--- a/src/components/Carousel/index.stories.js
+++ b/src/components/Carousel/index.stories.js
@@ -182,6 +182,21 @@ storiesOf('Components|Carousel', module)
 
 
             <PropExample
+              name='color'
+              type='String'
+            >
+                <Carousel
+                  className='row'
+                  showCount={responsiveValues(media, 3, 2, 1)}
+                  peek
+                  color='0, 255, 0'
+                >
+                  {tiles()}
+                </Carousel>
+            </PropExample>
+
+
+            <PropExample
               name='focusOnSelect'
               type='Boolean'
             >

--- a/src/styles/components/carousel/_modifiers.scss
+++ b/src/styles/components/carousel/_modifiers.scss
@@ -18,6 +18,7 @@
         padding-right: 15%;
       }
 
+      /*
       &:after {
         content: "";
         position: absolute;
@@ -34,6 +35,7 @@
         z-index: 1;
         pointer-events: none;
       }
+      */
     }
   }
 

--- a/src/styles/components/carousel/_modifiers.scss
+++ b/src/styles/components/carousel/_modifiers.scss
@@ -17,25 +17,6 @@
       @media only screen and (min-width: $mc-bp-lg) {
         padding-right: 15%;
       }
-
-      /*
-      &:after {
-        content: "";
-        position: absolute;
-        right: 0;
-        top: 0;
-        width: 120px;
-        height: 100%;
-        background:
-          linear-gradient(
-            to left,
-            rgba($mc-color-dark, 1) 0,
-            rgba($mc-color-dark, 0) 100%
-          ) center no-repeat;
-        z-index: 1;
-        pointer-events: none;
-      }
-      */
     }
   }
 


### PR DESCRIPTION
## Overview
adding the ability to set the gradient color for peeking

## Risks
Low - default color is still black.  Should see no observable difference in behavior without this new prop.

## Changes
![image](https://user-images.githubusercontent.com/56046844/78843221-10706980-79b7-11ea-83d0-af49dc854e3c.png)

## Issue
N/A

## Breaking change?
Backwards Compatible
