### PR TITLE
removed focusonselect from peek

### DIFF
--- a/src/components/Carousel/index.js
+++ b/src/components/Carousel/index.js
@@ -228,7 +228,7 @@ export default class Carousel extends PureComponent {
                 centerMode={centered}
                 centerPadding={0}
                 fade={transition === TRANSITION_FADE}
-                focusOnSelect={focusOnSelect || peek}
+                focusOnSelect={focusOnSelect}
                 ref={this.slider}
                 slidesToScroll={scrollCount}
                 slidesToShow={variableWidth ? 1 : showCount}


### PR DESCRIPTION
## Overview
when using the `peek` prop with carousel, it also forces `focusOnSelect` - I'm simply removing the forcing of `focusOnSelect` when using the peek prop.

## Risks
None

## Changes
N/A

## Issue
N/A

## Breaking change?
Backwards Compatible
