### PR TITLE
updating typography line-height and letter-spacing per designs request

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -9,9 +9,18 @@ $mc-font-default: "Lato", "Helvetica", "Arial", sans-serif !default; // Should b
 // Share line-height values between
 // the font definitions and the max-height
 // helper 'mc-text--2-line'
-$mc-lh-sm:  1.25 !default;
-$mc-lh-md:  1.5 !default;
-$mc-lh-lg:  1.7 !default;
+$mc-lh-headers: 1.45em !default;
+$mc-lh-lg:      1.7 !default;
+$mc-lh-md:      1.5 !default;
+$mc-lh-sm:      1.45 !default;
+$mc-lh-xs:      1.45 !default;
+
+$mc-ls-headers: 0.03em !default;
+$mc-ls-lg:      0 !default;
+$mc-ls-md:      0 !default;
+$mc-ls-sm:      0.01em !default;
+$mc-ls-xs:      0.01em !default;
+
 
 // Colors
 $mc-color-light:             #fff !default;

--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -10,7 +10,7 @@ body {
   font-variant-ligatures: none;
   text-rendering: optimizeLegibility;
   line-height: $mc-lh-md;
-  letter-spacing: 0.03em;
+  letter-spacing: $mc-ls-md;
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -53,26 +53,31 @@ a {
   &-h7,
   &-h8 {
     font-weight: 700;
-    line-height: $mc-lh-sm;
+    line-height: $mc-lh-headers;
+    letter-spacing: $mc-ls-headers;
   }
 
   &-large {
     @include step(font-size, 5);
     line-height: $mc-lh-lg;
+    letter-spacing: $mc-ls-lg;
   }
 
   &-medium {
     @include step(font-size, 4);
     line-height: $mc-lh-md;
+    letter-spacing: $mc-ls-md;
   }
 
   &-small {
     @include step(font-size, 3.5);
     line-height: $mc-lh-sm;
+    letter-spacing: $mc-ls-sm;
   }
 
   &-x-small {
     @include step(font-size, 3);
-    line-height: $mc-lh-sm;
+    line-height: $mc-lh-xs;
+    letter-spacing: $mc-ls-xs;
   }
 }


### PR DESCRIPTION
## Overview
Adjusting typography line-height for small and x-small type styles, and letter-spacing for body and large.

## Risks
Low - if for some reason some static heights (almost none) were decided based on the height calculated based on the line height of small or x-small text, they would be slightly off (by a couple pixels).  I don't believe that there are any cases like this, but there's no way to be certain.

## Changes

### Before

![image](https://user-images.githubusercontent.com/249444/79018127-dd011c80-7b27-11ea-864d-eb69774a58c9.png)

### After

![image](https://user-images.githubusercontent.com/249444/79020023-93670080-7b2c-11ea-9ccc-45e5f80a87ea.png)



## Issue
https://masterclass-dev.atlassian.net/browse/DS-159
https://masterclass-dev.atlassian.net/browse/DS-160

## Breaking change?
<Is this a breaking change, or is it backwards compatible? | *BREAKING* / Backwards Compatible>
