### PR TITLE
Incident-128: Added fullscreen/descendent check to modal

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -141,23 +141,28 @@ export default class Modal extends PureComponent {
     return false
   }
 
+  getRootNode = (fullscreenElement) => {
+    let rootNode
+    if (fullscreenElement &&
+    !this.isDescendant(this.container.current, fullscreenElement)) {
+      rootNode = fullscreenElement
+    } else {
+      rootNode = document.body
+    }
+
+    return rootNode
+  }
+
   render () {
     if (!this.props.show) return null
 
     if (this.props.appendToBody) {
       return (
         <FullscreenHandler>
-          {({ fullscreenElement }) => {
-            let rootNode
-            if (fullscreenElement &&
-            !this.isDescendant(this.container.current, fullscreenElement)) {
-              rootNode = fullscreenElement
-            } else {
-              rootNode = document.body
-            }
-
-            return createPortal(this.renderModal(), rootNode)
-          }}
+          {({ fullscreenElement }) => createPortal(
+            this.renderModal(),
+            this.getRootNode(fullscreenElement),
+          )}
         </FullscreenHandler>
       )
     }

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -129,16 +129,35 @@ export default class Modal extends PureComponent {
     )
   }
 
+  isDescendant = (parent, child) => {
+    let node = child.parentNode
+    while (node !== null) {
+      if (node === parent) {
+        return true
+      }
+      node = node.parentNode
+    }
+
+    return false
+  }
+
   render () {
     if (!this.props.show) return null
 
     if (this.props.appendToBody) {
       return (
         <FullscreenHandler>
-          {({ fullscreenElement }) => createPortal(
-            this.renderModal(),
-            fullscreenElement || document.body,
-          )}
+          {({ fullscreenElement }) => {
+            let rootNode
+            if (fullscreenElement &&
+            !this.isDescendant(this.container.current, fullscreenElement)) {
+              rootNode = fullscreenElement
+            } else {
+              rootNode = document.body
+            }
+
+            return createPortal(this.renderModal(), rootNode)
+          }}
         </FullscreenHandler>
       )
     }

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -129,22 +129,11 @@ export default class Modal extends PureComponent {
     )
   }
 
-  isDescendant = (parent, child) => {
-    let node = child.parentNode
-    while (node !== null) {
-      if (node === parent) {
-        return true
-      }
-      node = node.parentNode
-    }
-
-    return false
-  }
-
   getRootNode = (fullscreenElement) => {
     let rootNode
+
     if (fullscreenElement &&
-    !this.isDescendant(this.container.current, fullscreenElement)) {
+    fullscreenElement.closest('.mc-modal') !== this.container.current) {
       rootNode = fullscreenElement
     } else {
       rootNode = document.body


### PR DESCRIPTION
## Overview
There was a problem discovered on production where videos within a modal could not enter into fullscreen mode.  This PR fixes that, while also still allowing modals to be opened within a fullscreen element.

### Testing steps
#### Logged out
go to a cm page
click header video to open modal
click the fullscreen button and ensure it enters fullscreen mode successfully
#### Logged in
go to a class page
start last lesson in class
seek to end of video
ensure the NPS modal appears successfully

## Risks
None - this fixes an existing issue
## Changes
<How does this PR affect existing components? Please show screenshots or GIFs>

## Issue
Not sure if a ticket or issue was filed yet

## Breaking change?
Backwards compatible