### PR TITLE
Hide video play button on beforeScreen

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -479,10 +479,12 @@ export default class VideoPlayer extends PureComponent {
     } = this.state
 
     const isScreenOpen = screen !== SCREEN_NONE
+    const isScreenBefore = screen === SCREEN_BEFORE
 
     const containerClasses = cn({
       'bc-player': true,
       'bc-player--screen-open': isScreenOpen,
+      'bc-player--beforescreen': isScreenBefore,
     })
 
     const playerClasses = cn({

--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -484,7 +484,7 @@ export default class VideoPlayer extends PureComponent {
     const containerClasses = cn({
       'bc-player': true,
       'bc-player--screen-open': isScreenOpen,
-      'bc-player--beforescreen': isScreenBefore,
+      'bc-player--beforescreen-open': isScreenBefore,
     })
 
     const playerClasses = cn({

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -158,7 +158,7 @@ $mc-video-progress-height: 0.8rem !default;
     display: none;
   }
 
-  .bc-player--beforescreen & {
+  .bc-player--beforescreen-open & {
     display: none;
   }
 }

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -157,6 +157,10 @@ $mc-video-progress-height: 0.8rem !default;
   .vjs-has-started & {
     display: none;
   }
+
+  .bc-player--beforescreen & {
+    display: none;
+  }
 }
 
 


### PR DESCRIPTION
## Overview
A big video play button is shown on the before screen passed down as `beforeScreen` prop into `VideoPlayer` component, this behavior is unexpected.

This PR hides the video play button when `beforeScreen` is used.

## Risks
Low, just some style change.

## Changes
Before:
<img width="835" alt="Screen Shot 2020-04-22 at 11 42 13" src="https://user-images.githubusercontent.com/18334634/79997295-ce075c00-848f-11ea-897d-d1705851acc3.png">

After:
<img width="843" alt="Screen Shot 2020-04-22 at 11 29 34" src="https://user-images.githubusercontent.com/18334634/79997349-de1f3b80-848f-11ea-8801-6b79dda5f52f.png">


## Breaking change?
<Is this a breaking change, or is it backwards compatible? | *BREAKING* / Backwards Compatible>
