### PR TITLE
Adding "tap to unmute" for muted autoplay videos

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -5,6 +5,8 @@ import cn from 'classnames'
 import PropTypes from 'prop-types'
 
 import VideoPlayerScreen from '../VideoPlayerScreen'
+import Button from '../Button'
+import Icon from '../Icons'
 import { renderChildren } from '../helpers'
 
 const VOLUME_INTERVAL = 0.05
@@ -67,6 +69,7 @@ export default class VideoPlayer extends PureComponent {
   state = {
     screen: SCREEN_NONE,
     fill: FILL_NONE,
+    mutedAutoplay: false,
   }
 
   constructor (props) {
@@ -166,9 +169,10 @@ export default class VideoPlayer extends PureComponent {
     }
 
     if (hasAutoplay) {
-      const promise = this.video.play()
-      if (promise !== undefined) {
-        promise.catch(() => {})
+      const play = this.video.play()
+
+      if (play.catch) {
+        play.catch(this.muteAutoplay)
       }
     }
 
@@ -178,6 +182,23 @@ export default class VideoPlayer extends PureComponent {
     if (onVideoReady) {
       onVideoReady(this.video)
     }
+  }
+
+  muteAutoplay = () => {
+    this.video.muted(true)
+    const play = this.video.play()
+
+    if (play.catch) {
+      play
+        .then(() => this.setState({ mutedAutoplay: true }))
+        .catch(() => {})
+    }
+  }
+
+  unmuteAutoplay = () => {
+    this.video.muted(false)
+
+    this.setState({ mutedAutoplay: false })
   }
 
   turnOffCaptions = () => {
@@ -552,6 +573,20 @@ export default class VideoPlayer extends PureComponent {
               isActive: screen === SCREEN_END,
             })}
           </VideoPlayerScreen>
+        }
+
+        {this.state.mutedAutoplay &&
+          <Button
+            kind='secondary'
+            className='bc-player__autoplay-unmute'
+            onClick={this.unmuteAutoplay}
+          >
+            <Icon
+              kind='muted'
+              className='mc-mr-3'
+            />
+            Tap to Unmute
+          </Button>
         }
       </div>
     )

--- a/src/components/VideoPlayer/index.stories.js
+++ b/src/components/VideoPlayer/index.stories.js
@@ -44,6 +44,8 @@ storiesOf('Components|VideoPlayer', module)
       <DocSection title='Demo'>
         <div className='row'>
           <div className='col-12'>
+            <VideoPlayer hasAutoplay hasControls />
+
             <VideoPlayer
               hasControls
               beforescreenComponent={
@@ -215,7 +217,7 @@ storiesOf('Components|VideoPlayer', module)
         >
           <div className='row'>
             <div className='col-lg-4'>
-              <VideoPlayer hasAutoplay />
+              ...
             </div>
           </div>
         </PropExample>

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -81,6 +81,14 @@ $mc-video-progress-height: 0.8rem !default;
     }
   }
 
+  &__autoplay-unmute {
+    @include step(margin, 4);
+
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+
   .c-button {
     @include mc-button;
   }


### PR DESCRIPTION
## Overview
For videos that autoplay in browsers that don't support autoplay with audio, we mute the video, add an additional control that calls out "tap to unmute" and then autoplay the video.

## Risks
Low - if there are other overlays on videos there could be potential visual conflicts

## Changes
![image](https://user-images.githubusercontent.com/249444/81258829-6999e000-8feb-11ea-90d7-a077cdf52c60.png)

<img width="584" alt="Screen Shot 2020-05-06 at 10 47 01 PM" src="https://user-images.githubusercontent.com/249444/81258891-8afacc00-8feb-11ea-9e01-0843a973dc01.png">



## Issue
#713 

## Breaking change?
Backwards Compatible
