### PR TITLE
dont run cleanup if video instance doesnt exist

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -107,7 +107,10 @@ export default class VideoPlayer extends PureComponent {
   }
 
   componentWillUnmount () {
-    // clean listeners and DOM
+    // Don't run cleanup if video instance doesn't exist
+    if (!this.video) { return }
+
+    // Cleanup
     this.video.off('play')
     this.video.off('pause')
     this.video.off('ended')


### PR DESCRIPTION
## Overview
When unmounting the VideoPlayer component, check to see if the video instance exists before executing cleanup (otherwise an exception is thrown that kills the UI)

## Risks
None

## Changes
None

## Issue
https://masterclass-dev.atlassian.net/browse/BLAM-81

## Breaking change?
Backwards Compatible
