### PR TITLE
Adding bright badge type

### DIFF
--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -12,6 +12,7 @@ export default class Badge extends PureComponent {
       'default',
       'primary',
       'transparent',
+      'bright',
     ]),
   }
 

--- a/src/components/Badge/index.stories.js
+++ b/src/components/Badge/index.stories.js
@@ -19,21 +19,27 @@ storiesOf('Components|Badge', module)
 
       <InvertedMirror>
         <div className='row mc-text--center'>
-          <div className='col-12 col-sm-4'>
+          <div className='col-12 col-sm-6'>
             <Badge>
               Default
             </Badge>
           </div>
 
-          <div className='col-12 col-sm-4'>
+          <div className='col-12 col-sm-6'>
             <Badge kind='primary'>
               Primary
             </Badge>
           </div>
 
-          <div className='col-12 col-sm-4'>
+          <div className='col-12 col-sm-6'>
             <Badge kind='transparent'>
               Transparent
+            </Badge>
+          </div>
+
+          <div className='col-12 col-sm-6'>
+            <Badge kind='bright'>
+              Bright
             </Badge>
           </div>
         </div>

--- a/src/styles/components/_badge.scss
+++ b/src/styles/components/_badge.scss
@@ -21,4 +21,9 @@
     color: var(--mc-theme-text);
     box-shadow: inset 0 0 0 1px var(--mc-theme-border-contrast);
   }
+
+  &--bright {
+    background: var(--mc-theme-badge-bright-bg);
+    color: var(--mc-theme-badge-bright-text);
+  }
 }

--- a/src/styles/helpers/_theme-css-vars.scss
+++ b/src/styles/helpers/_theme-css-vars.scss
@@ -11,17 +11,24 @@
   --mc-theme-border-contrast:         #{rgba($mc-color-light, 0.5)};
   --mc-theme-border-contrast-hover:   #{$mc-color-light};
   --mc-theme-applepay-border:         none;
+
+  // Badges
+  --mc-theme-badge-bright-bg:        #{$mc-color-light};
+  --mc-theme-badge-bright-text:      #{$mc-color-dark};
+
   // Dropdown colors
   --mc-theme-dropdown-backdrop:   #{rgba($mc-color-dark, 0.9)};
   --mc-theme-dropdown-border:     #{$mc-color-gray-200};
   --mc-theme-dropdown-bg:         #{$mc-color-gray-100};
   --mc-theme-dropdown-shadow:     #{$mc-color-dark};
   --mc-theme-dropdown-hover-bg:   #{$mc-color-gray-200};
+
   // Tooltip colors
   --mc-theme-tooltip-bg:            #{$mc-color-gray-200};
   --mc-theme-tooltip-border:        #{$mc-color-gray-400};
   --mc-theme-tooltip-arrow:         #{$mc-color-gray-400};
   --mc-theme-tooltip-arrow-after:   #{$mc-color-gray-200};
+
   // Checkbox colors
   --mc-theme-checkbox-bg:                 #{$mc-color-gray-100};
   --mc-theme-checkbox-border:             #{$mc-color-gray-200};
@@ -30,6 +37,7 @@
   --mc-theme-checkbox-dis-bg:             #{$mc-color-gray-700};
   --mc-theme-checkbox-dis-border:         #{$mc-color-gray-600};
   --mc-theme-checkbox-dis-active-border:  #{$mc-color-gray-200};
+
   // Form element colors
   --mc-theme-form-bg:                     #{$mc-color-gray-100};
   --mc-theme-form-border:                 #{$mc-color-gray-200};
@@ -40,12 +48,14 @@
   --mc-theme-form-dis-active:             none;
   --mc-theme-form-dis-elem:               #{rgba($mc-color-light, 0.5)};
   --mc-theme-form-append:                 #{rgba($mc-color-light, 0.3)};
+
   // Radio colors
   --mc-theme-radio-bg:          #{$mc-color-gray-100};
   --mc-theme-radio-border:      #{$mc-color-gray-200};
   --mc-theme-radio-checked:     #{$mc-color-light};
   --mc-theme-radio-dis-bg:      var(--mc-theme-radio-bg);
   --mc-theme-radio-dis-border:  none;
+
   // Select colors
   --mc-theme-select-menu-bg:      #{$mc-color-gray-100};
   --mc-theme-select-menu-border:  #{$mc-color-gray-200};
@@ -64,15 +74,22 @@
   --mc-theme-border-contrast:         #{rgba($mc-color-dark, 0.5)};
   --mc-theme-border-contrast-hover:   #{$mc-color-dark};
   --mc-theme-applepay-border:         inset 0 0 0 1px #{$mc-color-dark};
+
+  // Badges
+  --mc-theme-badge-bright-bg:        #{$mc-color-gray-600};
+  --mc-theme-badge-bright-text:      #{$mc-color-dark};
+
   // Dropdown colors
   --mc-theme-dropdown-border:     #{$mc-color-gray-700};
   --mc-theme-dropdown-bg:         #{$mc-color-light};
   --mc-theme-dropdown-hover-bg:   #{$mc-color-gray-700};
+
   // Tooltip colors
   --mc-theme-tooltip-bg:            #{$mc-color-light};
   --mc-theme-tooltip-border:        #{$mc-color-gray-700};
   --mc-theme-tooltip-arrow:         #{$mc-color-gray-700};
   --mc-theme-tooltip-arrow-after:   #{$mc-color-light};
+
   // Checkbox colors
   --mc-theme-checkbox-bg:                 #{$mc-color-light};
   --mc-theme-checkbox-border:             #{$mc-color-gray-500};
@@ -81,6 +98,7 @@
   --mc-theme-checkbox-dis-bg:             #{$mc-color-gray-700};
   --mc-theme-checkbox-dis-border:         #{$mc-color-gray-600};
   --mc-theme-checkbox-dis-active-border:  #{$mc-color-gray-600};
+
   // Form element colors
   --mc-theme-form-bg:                     #{$mc-color-light};
   --mc-theme-form-border:                 #{$mc-color-gray-500};
@@ -91,12 +109,14 @@
   --mc-theme-form-dis-active:             #{$mc-color-gray-600};
   --mc-theme-form-dis-elem:               #{rgba($mc-color-dark, 0.3)};
   --mc-theme-form-append:                 #{rgba($mc-color-dark, 0.3)};
+
   // Radio colors
   --mc-theme-radio-bg:          #{$mc-color-light};
   --mc-theme-radio-border:      #{$mc-color-gray-500};
   --mc-theme-radio-checked:     #{$mc-color-dark};
   --mc-theme-radio-dis-bg:      #{$mc-color-gray-700};
   --mc-theme-radio-dis-border:  inset 0 0 0 1px #{$mc-color-gray-600};
+
   // Select colors
   --mc-theme-select-menu-bg:      #{$mc-color-light};
   --mc-theme-select-menu-border:  #{$mc-color-gray-700};

--- a/src/utils/InvertedMirror.js
+++ b/src/utils/InvertedMirror.js
@@ -32,6 +32,9 @@ export default class InvertedMirror extends PureComponent {
               color='light'
               className='mc-card mc-invert'
             >
+              <h5 className='mc-text-h5 mc-mb-7 mc-text--center'>
+                Inverted
+              </h5>
               {children}
             </Background>
           </div>
@@ -41,6 +44,9 @@ export default class InvertedMirror extends PureComponent {
               color='dark'
               className='mc-card'
             >
+              <h5 className='mc-text-h5 mc-mb-7 mc-text--center'>
+                Default
+              </h5>
               {children}
             </Background>
           </div>


### PR DESCRIPTION
## Overview
Design requested a new "bright" badge type.

## Risks
None

## Changes
Adds new type of badge called "bright":
![image](https://user-images.githubusercontent.com/505670/83459074-8245bc00-a418-11ea-877b-be68c373b472.png)

## Issue
https://masterclass-dev.atlassian.net/browse/DS-170

## Breaking change?
Backwards Compatible