### PR TITLE
<Button kind='apple' />

### DIFF
--- a/src/components/Button/index.stories.js
+++ b/src/components/Button/index.stories.js
@@ -213,7 +213,7 @@ class ButtonStory extends PureComponent {
                   </Button>
                 </div>
                 <div className='col-auto'>
-                  <Button kind='applepay'>
+                  <Button kind='apple'>
                     Apple pay
                   </Button>
                 </div>

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -60,12 +60,12 @@ $mc-color-reward-end:   #e5a754 !default;
 $mc-color-highlight:    $mc-color-reward !default;
 
 // External brands
-$mc-color-facebook:     #3c5a99 !default;
-$mc-color-google:       #4285f4 !default;
-$mc-color-twitter:      #2ba2ef !default;
-$mc-color-paypal:       #ffc439 !default;
-$mc-color-pinterest:    #bd081c !default;
-$mc-color-applepay:     #fff !default;
+$mc-color-facebook:         #3c5a99 !default;
+$mc-color-google:           #4285f4 !default;
+$mc-color-twitter:          #2ba2ef !default;
+$mc-color-paypal:           #ffc439 !default;
+$mc-color-pinterest:        #bd081c !default;
+$mc-color-apple:            #000 !default;
 
 // The yiq lightness value that determines when the
 // lightness of color changes from "dark" to "light".

--- a/src/styles/components/buttons/_buttons.scss
+++ b/src/styles/components/buttons/_buttons.scss
@@ -259,19 +259,17 @@
     }
   }
 
-  &--applepay {
-    background-color: $mc-color-applepay;
-    color: $mc-color-dark;
-    box-shadow: var(--mc-theme-applepay-border);
+  &--apple {
+    background-color: $mc-color-apple;
 
     &:not(:disabled):not(.disabled) {
       &:hover {
-        background-color: lighten($mc-color-applepay, 6.5%);
+        background-color: $mc-color-apple;
         color: $mc-color-dark;
       }
 
       &:active {
-        background-color: $mc-color-applepay;
+        background-color: $mc-color-apple;
         color: $mc-color-dark;
       }
     }


### PR DESCRIPTION
## Overview
Replacing the ApplePay button with Apple, as they should be unified and not so specific.  Apple's branding guidelines work for all of it's buttons.

## Risks
Low - this deprecates `<Button kind='apple-pay'/>` and replaces it with <Button kind='apple' />.  Those instances need to get replaced.

## Changes
Before
![image](https://user-images.githubusercontent.com/249444/83531977-7ef71280-a4a2-11ea-92a9-e7e6f616eddf.png)

After
<How does this PR affect existing components? Please show screenshots or GIFs>
![image](https://user-images.githubusercontent.com/249444/83531835-540cbe80-a4a2-11ea-9849-db57ef00b067.png)


## Breaking change?
*BREAKING* - but not major
