### PR TITLE
Scale values to utilize CSS variables

### DIFF
--- a/.storybook/_upside-down.scss
+++ b/.storybook/_upside-down.scss
@@ -55,23 +55,23 @@ a {
 }
 
 .example__heading {
-  @include step(padding-top, 8);
-  @include step(margin-bottom, 8);
+  padding-top: var(--mc-scale-8);
+  margin-bottom: var(--mc-scale-8);
 }
 
 .example__section {
-  @include step(margin-top, 8);
-  @include step(margin-bottom, 10);
+  margin-top: var(--mc-scale-8);
+  margin-bottom: var(--mc-scale-10);
 }
 
 .example__definition {
-  @include step(margin-bottom, 5);
+  margin-bottom: var(--mc-scale-5);
 }
 
 .example__render {
-  @include step(padding-top, 4);
-  @include step(padding-bottom, 4);
-  @include step(margin-bottom, 4);
+  padding-top: var(--mc-scale-4);
+  padding-bottom: var(--mc-scale-4);
+  margin-bottom: var(--mc-scale-4);
 
   .mc-theme-light,
   .mc-invert & {
@@ -80,11 +80,11 @@ a {
 }
 
 .example__trigger {
-  @include step(margin-bottom, 4);
+  margin-bottom: var(--mc-scale-4);
 }
 
 .example__code {
-  @include step(margin-bottom, 4);
+  margin-bottom: var(--mc-scale-4);
 }
 
 .example__table {
@@ -112,7 +112,7 @@ a {
   }
 
   th, td {
-    @include step(padding, 2);
+    padding: var(--mc-scale-2);
   }
 }
 
@@ -200,8 +200,8 @@ a {
     }
 
     &__box-#{$i} {
-      @include step(width, $i);
-      @include step(height, $i);
+      width: var(--mc-scale-#{$i});
+      height: var(--mc-scale-#{$i});
     }
 
     $rem-sm: calc-step($i, $mc-step-decay-sm);
@@ -310,7 +310,7 @@ a {
   position: fixed;
   right: 0;
   bottom: 0;
-  @include step(padding, 2);
+  padding: var(--mc-scale-2);
   z-index: 9999;
   display: flex;
   align-items: center;

--- a/src/foundation/scale/index.stories.js
+++ b/src/foundation/scale/index.stories.js
@@ -187,7 +187,7 @@ class Scale extends PureComponent {
 
           <Highlight className='language-scss mc-mb-8'>
 {`.some-container {
-  @include step(padding, 5)
+  padding: var(--mc-scale-5);
 }`}
           </Highlight>
 

--- a/src/styles/base/_functions.scss
+++ b/src/styles/base/_functions.scss
@@ -50,5 +50,5 @@
   $less: (max($step - $mc-step-min-resize, 0) * $decay) / $mc-step-base;
   $value: $level * $mc-step-scale * $factor / $mc-step-base;
 
-  @return $value - $less;
+  @return $value - $less * 1rem;
 }

--- a/src/styles/base/mixins/_step.scss
+++ b/src/styles/base/mixins/_step.scss
@@ -1,20 +1,5 @@
 @mixin step($attribute, $value, $i: false) {
   $important: if($i, "!important", "");
-  $calc-sm: calc-step($value, $mc-step-decay-sm);
-  $calc-md: calc-step($value, $mc-step-decay-md);
-  $calc-lg: calc-step($value, $mc-step-decay-lg);
 
-  #{$attribute}: $calc-sm * 1rem #{$important};
-
-  @if $calc-md != $calc-sm {
-    @media (min-width: $mc-bp-md) {
-      #{$attribute}: $calc-md * 1rem #{$important};
-    }
-  }
-
-  @if $calc-lg != $calc-sm {
-    @media (min-width: $mc-bp-lg) {
-      #{$attribute}: $calc-lg * 1rem #{$important};
-    }
-  }
+  #{$attribute}: var(--mc-scale-#{$value}) #{$important};
 }

--- a/src/styles/components/_badge.scss
+++ b/src/styles/components/_badge.scss
@@ -4,10 +4,10 @@
   color: $mc-color-light;
   border-radius: 20px;
 
-  @include step(padding-top, 1);
-  @include step(padding-right, 3);
-  @include step(padding-bottom, 1);
-  @include step(padding-left, 3);
+  padding-top: var(--mc-scale-1);
+  padding-right: var(--mc-scale-3);
+  padding-bottom: var(--mc-scale-1);
+  padding-left: var(--mc-scale-3);
 
   &--default {
     background: $mc-color-secondary;

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -78,7 +78,7 @@
     right: 0;
     top: 0;
 
-    @include step(margin, 2);
+    margin: var(--mc-scale-2);
     opacity: 0.5;
     z-index: $mc-zindex-modal + 2;
     cursor: pointer;

--- a/src/styles/components/_tooltip.scss
+++ b/src/styles/components/_tooltip.scss
@@ -17,7 +17,7 @@
   }
 
   &__content {
-    @include step(padding, 3);
+    padding: var(--mc-scale-3);
 
     background: var(--mc-theme-tooltip-bg);
     border: 1px solid var(--mc-theme-tooltip-border);

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -82,7 +82,7 @@ $mc-video-progress-height: 0.8rem !default;
   }
 
   &__autoplay-unmute {
-    @include step(margin, 4);
+    margin: var(--mc-scale-4);
 
     position: absolute;
     left: 0;

--- a/src/styles/components/buttons/_buttons.scss
+++ b/src/styles/components/buttons/_buttons.scss
@@ -1,9 +1,9 @@
 @mixin mc-button {
-  @include step(padding-top, 3);
-  @include step(padding-right, 5);
-  @include step(padding-bottom, 3);
-  @include step(padding-left, 5);
-  @include step(font-size, 3);
+  padding-top: var(--mc-scale-3);
+  padding-right: var(--mc-scale-5);
+  padding-bottom: var(--mc-scale-3);
+  padding-left: var(--mc-scale-5);
+  font-size: var(--mc-scale-3);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -42,10 +42,10 @@
   // Variations
 
   &--small {
-    @include step(padding-top, 1);
-    @include step(padding-bottom, 1);
-    @include step(padding-left, 3);
-    @include step(padding-right, 3);
+    padding-top: var(--mc-scale-1);
+    padding-bottom: var(--mc-scale-1);
+    padding-left: var(--mc-scale-3);
+    padding-right: var(--mc-scale-3);
   }
 
   &--full-width {
@@ -164,11 +164,11 @@
   }
 
   &--symmetrical {
-    @include step(padding, 3);
+    padding: var(--mc-scale-3);
 
     /* stylelint-disable-next-line */
     &.c-button--small {
-      @include step(padding, 1);
+      padding: var(--mc-scale-1);
     }
   }
 

--- a/src/styles/foundation/_foundation.scss
+++ b/src/styles/foundation/_foundation.scss
@@ -1,0 +1,1 @@
+@import "scale";

--- a/src/styles/foundation/_scale.scss
+++ b/src/styles/foundation/_scale.scss
@@ -1,0 +1,17 @@
+:root {
+  @for $i from $scale-begin through $scale-end {
+    --mc-scale-#{$i}: #{calc-step($i, $mc-step-decay-sm)};
+  }
+
+  @media (min-width: $mc-bp-md) {
+    @for $i from $scale-begin through $scale-end {
+      --mc-scale-#{$i}: #{calc-step($i, $mc-step-decay-md)};
+    }
+  }
+
+  @media (min-width: $mc-bp-lg) {
+    @for $i from $scale-begin through $scale-end {
+      --mc-scale-#{$i}: #{calc-step($i, $mc-step-decay-lg)};
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,4 +1,5 @@
 @import "base/base";
+@import "foundation/foundation";
 @import "animation/animation";
 @import "libraries/libraries";
 @import "body/body";

--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -32,14 +32,14 @@ a {
   &-d2 { @include step(font-size, 11); }
   &-d1 { @include step(font-size, 10); }
 
-  &-h1 { @include step(font-size, 9); }
-  &-h2 { @include step(font-size, 8); }
-  &-h3 { @include step(font-size, 7); }
-  &-h4 { @include step(font-size, 6); }
-  &-h5 { @include step(font-size, 5); }
-  &-h6 { @include step(font-size, 4); }
+  &-h1 { font-size: var(--mc-scale-9); }
+  &-h2 { font-size: var(--mc-scale-8); }
+  &-h3 { font-size: var(--mc-scale-7); }
+  &-h4 { font-size: var(--mc-scale-6); }
+  &-h5 { font-size: var(--mc-scale-5); }
+  &-h6 { font-size: var(--mc-scale-4); }
   &-h7 { @include step(font-size, 3.5); }
-  &-h8 { @include step(font-size, 3); }
+  &-h8 { font-size: var(--mc-scale-3); }
 
   &-d3,
   &-d2,
@@ -58,13 +58,13 @@ a {
   }
 
   &-large {
-    @include step(font-size, 5);
+    font-size: var(--mc-scale-5);
     line-height: $mc-lh-lg;
     letter-spacing: $mc-ls-lg;
   }
 
   &-medium {
-    @include step(font-size, 4);
+    font-size: var(--mc-scale-4);
     line-height: $mc-lh-md;
     letter-spacing: $mc-ls-md;
   }
@@ -76,7 +76,7 @@ a {
   }
 
   &-x-small {
-    @include step(font-size, 3);
+    font-size: var(--mc-scale-3);
     line-height: $mc-lh-xs;
     letter-spacing: $mc-ls-xs;
   }


### PR DESCRIPTION
## Overview
Moving scale values to CSS variables. This allows us to reduce the LOC and complexity around using scale step values. The CSS output goes from 130kb -> 116kb (~5500 -> ~4500 LOC). Previously, we would use a SCSS mixin:

```scss
@import "~mc-components/dist/styles/scss/base/base";

.example {
  @include step(padding: 6);
}
```

which would output:

```css
.example {
  padding: 2rem;
}

@media (min-width: 768px) {
  .example {
    padding: 2.2rem;
  }
}

@media (min-width: 960px) {
  .example {
    padding: 2.4rem;
  }
}
```

Instead, we can now just use the CSS variable, and the our code is the same as the output

```scss
.example {
  padding: var(--mc-scale-6)
}
```

## Risks
Low - the existing mixin, which is used quite a bit, still works.  It just outputs the CSS variable now instead.

## Breaking change?
Backwards Compatible
