### PR TITLE
fixing bug with .mc-text-small size

### DIFF
--- a/src/styles/foundation/_scale.scss
+++ b/src/styles/foundation/_scale.scss
@@ -3,6 +3,8 @@
     --mc-scale-#{$i}: #{calc-step($i, $mc-step-decay-sm)};
   }
 
+  --mc-scale-3-5: #{calc-step(3.5, $mc-step-decay-sm)};
+
   @media (min-width: $mc-bp-md) {
     @for $i from $scale-begin through $scale-end {
       --mc-scale-#{$i}: #{calc-step($i, $mc-step-decay-md)};

--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -70,7 +70,11 @@ a {
   }
 
   &-small {
-    @include step(font-size, 3.5);
+    // TODO JJ - Kill this at your earliest convenience
+    // This exists outside of the scale system because
+    // half steps are not supported...except in this case
+    // because design insisted on a 14px font :|
+    font-size: calc-step(3.5, $mc-step-decay-sm);
     line-height: $mc-lh-sm;
     letter-spacing: $mc-ls-sm;
   }

--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -38,7 +38,7 @@ a {
   &-h4 { font-size: var(--mc-scale-6); }
   &-h5 { font-size: var(--mc-scale-5); }
   &-h6 { font-size: var(--mc-scale-4); }
-  &-h7 { @include step(font-size, 3.5); }
+  &-h7 { font-size: var(--mc-scale-3-5); }
   &-h8 { font-size: var(--mc-scale-3); }
 
   &-d3,
@@ -70,11 +70,7 @@ a {
   }
 
   &-small {
-    // TODO JJ - Kill this at your earliest convenience
-    // This exists outside of the scale system because
-    // half steps are not supported...except in this case
-    // because design insisted on a 14px font :|
-    font-size: calc-step(3.5, $mc-step-decay-sm);
+    font-size: var(--mc-scale-3-5);
     line-height: $mc-lh-sm;
     letter-spacing: $mc-ls-sm;
   }


### PR DESCRIPTION
## Overview
with the new CSS vars for scale sizes, had to override this odd font size (3.5 on the scale)

## Risks
None - solves a bug where `.mc-text-small` is just the default body size

## Breaking change?
Backwards Compatible
