### PR TITLE
Local play should  be calling video.play and not pause

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -194,7 +194,7 @@ export default class VideoPlayer extends PureComponent {
     if (this.props.hasAutoplay) {
       this.unmutePlay()
     } else {
-      this.video.pause()
+      this.video.play()
     }
   }
 


### PR DESCRIPTION
## Overview
<General description>
Right now, the video player's `onResume` function is not calling the "play" action when the prop `hasAutoplay` is false, causing the video player not correctly resuming the video playing.

## Risks
Medium: This affects all video players on masterclass

## Changes
![Screen Shot 2020-06-11 at 12 24 07](https://user-images.githubusercontent.com/8084303/84405441-7dce8f80-abde-11ea-82a2-905b8f19e64b.png)
![Screen Shot 2020-06-11 at 12 24 22](https://user-images.githubusercontent.com/8084303/84405500-976fd700-abde-11ea-9adc-317360d7b1aa.png)

# OnResume being called but hasAutoplay is false
![onResume not working, hasAutoplay is false](https://user-images.githubusercontent.com/8084303/84406088-6d6ae480-abdf-11ea-9644-9ebf6f67e070.gif)

# OnResume being called but hasAutoplay is true
![onResume is working, but hasAutoplay is true](https://user-images.githubusercontent.com/8084303/84406440-e8cc9600-abdf-11ea-92d6-33ca82af42c7.gif)

## Issue
<Does this PR fix an existing issue? If so, link to it here>

## Breaking change?
<Is this a breaking change, or is it backwards compatible? | *BREAKING* / Backwards Compatible>
