### PR TITLE
CI w/ GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Lint
         uses: github/super-linter@v2.0.0
+        env:
+          VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,21 @@
 name: CI
-on: [pull_request]
+on: pull_request
 
 jobs:
-  lint:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install
+        uses: CultureHQ/actions-yarn@master
+        with:
+          args: install
       - name: Lint
         uses: github/super-linter@v2.0.0
         env:
           VALIDATE_ALL_CODEBASE: false
+      - name: Build
+        uses: CultureHQ/actions-yarn@master
+        with:
+          args: build

--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,11 @@
+name: Lint
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Lint
+        uses: github/super-linter@v2.0.0


### PR DESCRIPTION
## Overview
See "Checks" tab, notice lint/build running in GitHub actions

## Risks
Low - simply transferring checks from CCI to GH Actions.  Highest risk - checks failing because they are not set up correctly


## Breaking change?
Backwards Compatible
