### PR TITLE
Fix rempx bug on scale demo

### DIFF
--- a/.storybook/_upside-down.scss
+++ b/.storybook/_upside-down.scss
@@ -204,9 +204,11 @@ a {
       height: var(--mc-scale-#{$i});
     }
 
-    $rem-sm: calc-step($i, $mc-step-decay-sm);
-    $rem-md: calc-step($i, $mc-step-decay-md);
-    $rem-lg: calc-step($i, $mc-step-decay-lg);
+    // divide by 1rem to 'strip' the unit off the function
+    // JUST for storybook.
+    $rem-sm: calc-step($i, $mc-step-decay-sm) / 1rem;
+    $rem-md: calc-step($i, $mc-step-decay-md) / 1rem;
+    $rem-lg: calc-step($i, $mc-step-decay-lg) / 1rem;
 
     &__label-#{$i}-sm-px:before {
       content: "#{$rem-sm * $mc-step-base}";


### PR DESCRIPTION
## Overview
We had a bug on the storybook scale page after the refactoring of the scale to use css variables where it was rendering the demo with `rempx` values.
![image](https://user-images.githubusercontent.com/505670/85455588-e872ba00-b552-11ea-9284-52748db23cc5.png)

Fixed:
![image](https://user-images.githubusercontent.com/505670/85455610-ef013180-b552-11ea-9d2c-00e35ebd0cf6.png)


## Risks
None - only affects storybook scss file.

## Changes
Updates the "scale" story to show the correct px values for scale values.

## Issue
https://github.com/yankaindustries/mc-components/issues/728

## Breaking change?
Backwards Compatible
