### PR TITLE
Fix end screen blocking clicks

### DIFF
--- a/src/components/VideoPlayerScreen/index.js
+++ b/src/components/VideoPlayerScreen/index.js
@@ -7,10 +7,6 @@ import VideoPlayerPortalScreen from '../VideoPlayerPortalScreen'
 import { PROP_TYPE_CHILDREN } from '../constants'
 
 
-const endListener = (node, done) =>
-  node.addEventListener('transitionend', done, false)
-
-
 const VideoPlayerScreen = ({
   isActive,
   variation,
@@ -30,7 +26,6 @@ const VideoPlayerScreen = ({
         appear={isActive}
         in={isActive}
         classNames='bc-player__screen-'
-        addEndListener={endListener}
       >
         <div className={classNames}>
           {children}

--- a/src/components/VideoPlayerScreen/index.js
+++ b/src/components/VideoPlayerScreen/index.js
@@ -6,7 +6,6 @@ import cn from 'classnames'
 import VideoPlayerPortalScreen from '../VideoPlayerPortalScreen'
 import { PROP_TYPE_CHILDREN } from '../constants'
 
-
 const VideoPlayerScreen = ({
   isActive,
   variation,
@@ -26,6 +25,7 @@ const VideoPlayerScreen = ({
         appear={isActive}
         in={isActive}
         classNames='bc-player__screen-'
+        timeout={500}
       >
         <div className={classNames}>
           {children}


### PR DESCRIPTION
## Overview
After the end screen exits, the user wasn't able to interact with the video player clicking the screen for pausing or resuming.

Looks like a wrong state of the transition was adding a class to the end screen component when it should be hidden.
![image (30)](https://user-images.githubusercontent.com/18464392/88726245-c2b57380-d103-11ea-9103-1c129d944a6c.png)

More info here: https://masterclass-dev.atlassian.net/browse/WE-202

## Risks
Medium. Not sure why we had that function for defining when the transition ends, but maybe the code reviewers can clarify this.

## Breaking change?
No
