### PR TITLE
Updating font to Sohne

### DIFF
--- a/.storybook/_upside-down.scss
+++ b/.storybook/_upside-down.scss
@@ -356,8 +356,8 @@ a {
   font-weight: 300;
   font-display: swap;
   src: local('Sohne Leicht'), local('Sohne-Leicht'),
-    url('//www.masterclass.com/fonts/sohne-leicht.woff2') format('woff2'),
-    url('//www.masterclass.com/fonts/sohne-leicht.woff') format('woff');
+    url('//masterclass.com/fonts/sohne-leicht.woff2') format('woff2'),
+    url('//masterclass.com/fonts/sohne-leicht.woff') format('woff');
 }
 
 /* Sohne - Regular */
@@ -367,8 +367,8 @@ a {
   font-weight: 400;
   font-display: swap;
   src: local('Sohne Buch'), local('Sohne-Buch'),
-    url('//www.masterclass.com/fonts/sohne-buch.woff2') format('woff2'),
-    url('//www.masterclass.com/fonts/sohne-buch.woff') format('woff');
+    url('//masterclass.com/fonts/sohne-buch.woff2') format('woff2'),
+    url('//masterclass.com/fonts/sohne-buch.woff') format('woff');
 }
 
 /* Sohne - Bold */
@@ -378,6 +378,6 @@ a {
   font-weight: 500;
   font-display: swap;
   src: local('Sohne Halbfett'), local('Sohne-Halbfett'),
-    url('//www.masterclass.com/fonts/sohne-halbfett.woff2') format('woff2'),
-    url('//www.masterclass.com/fonts/sohne-halbfett.woff') format('woff');
+    url('//masterclass.com/fonts/sohne-halbfett.woff2') format('woff2'),
+    url('//masterclass.com/fonts/sohne-halbfett.woff') format('woff');
 }

--- a/.storybook/_upside-down.scss
+++ b/.storybook/_upside-down.scss
@@ -6,7 +6,6 @@
 // yet, so they'll live here!
 
 // THE UPSIDE DOWN
-
 .mc-card {
   padding: $grid-gutter-width-xl / 2;
 
@@ -346,4 +345,39 @@ a {
       transition-delay: 0s;
     }
   }
+}
+
+
+// Font includes
+/* Sohne - Light */
+@font-face {
+  font-family: 'Sohne';
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: local('Sohne Leicht'), local('Sohne-Leicht'),
+    url('//www.masterclass.com/fonts/sohne-leicht.woff2') format('woff2'),
+    url('//www.masterclass.com/fonts/sohne-leicht.woff') format('woff');
+}
+
+/* Sohne - Regular */
+@font-face {
+  font-family: 'Sohne';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Sohne Buch'), local('Sohne-Buch'),
+    url('//www.masterclass.com/fonts/sohne-buch.woff2') format('woff2'),
+    url('//www.masterclass.com/fonts/sohne-buch.woff') format('woff');
+}
+
+/* Sohne - Bold */
+@font-face {
+  font-family: 'Sohne';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: local('Sohne Halbfett'), local('Sohne-Halbfett'),
+    url('//www.masterclass.com/fonts/sohne-halbfett.woff2') format('woff2'),
+    url('//www.masterclass.com/fonts/sohne-halbfett.woff') format('woff');
 }

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link href="https://fonts.googleapis.com/css?family=Lato:300,400,700" rel="stylesheet">
+<!-- Loaded on every storybook view pane -->

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The style library must also be imported manually into your root `SCSS` file.
 @import 'mc-components/dist/styles/scss/index'
 ```
 
-We use Lato as our primary font for headings and body text.  You can import it in your CSS below, or import it into your asset pipeline.
+Masterclass uses the licensed font "Sohne" as its primary font for headings and body text. You can replace the references to this font stack by updating the `$mc-font-default` variable in the style variables file.
 
 ```scss
-@import url("https://fonts.googleapis.com/css?family=Lato:300,400,700")
+src/styles/base/variables.scss
 ```
 
 # Development

--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -4,7 +4,7 @@
 // mc-font, mc-color, mc-contain, mc-asset
 
 // Fonts
-$mc-font-default: "Lato", "Helvetica", "Arial", sans-serif !default; // Should be used in most cases
+$mc-font-default: "Sohne", "Helvetica", "Arial", sans-serif !default; // Should be used in most cases
 
 // Share line-height values between
 // the font definitions and the max-height


### PR DESCRIPTION
## Overview
Masterclass is going through a rebrand!  This is the first step - swapping Lato with Sohne.

## Risks
Low - The font will still render as a default (Helvetica and Arial) if Sohne isn't available. 

## Changes
![image](https://user-images.githubusercontent.com/505670/90566814-f9f4ce80-e15d-11ea-9657-787589220a17.png)

## Issue
N/A

## Breaking change?
**BREAKING** This change will require updates in the consumer apps.  The font is changing, so imports will need to be updated.