### PR TITLE
We only load 500 weights, not 700

### DIFF
--- a/src/styles/typography/_base.scss
+++ b/src/styles/typography/_base.scss
@@ -52,7 +52,7 @@ a {
   &-h6,
   &-h7,
   &-h8 {
-    font-weight: 700;
+    font-weight: 500;
     line-height: $mc-lh-headers;
     letter-spacing: $mc-ls-headers;
   }


### PR DESCRIPTION
## Overview
@jstnjns had the 700 font weight locally and noticed all the fonts on the review app looked too heavy.  After digging in, I realized I forgot to update the font weights in mc-components when swapping Lato with Sohne.  This PR updates the font weight for the headings to be the correct weight.

## Risks
Low - just a weight change.

## Changes
No visual changes to the majority of users (only users who had the `Sohne` font installed locally would see any difference...which is basically just @jstnjns).

## Issue
N/A

## Breaking change?
Backwards compatible
