### PR TITLE
VideoPlayer - odd bug fix

### DIFF
--- a/src/components/VideoPlayer/index.js
+++ b/src/components/VideoPlayer/index.js
@@ -525,6 +525,7 @@ export default class VideoPlayer extends PureComponent {
       'bc-player__video': true,
       'bc-player__video--default': true,
       'video-js': true,
+      'vjs-tech': true,
       [`vjs-fill-${fill}`]: !!fill,
     })
 

--- a/src/styles/components/_video-player.scss
+++ b/src/styles/components/_video-player.scss
@@ -16,8 +16,8 @@ $mc-video-progress-height: 0.8rem !default;
 
   &__video {
     position: absolute;
-    left: 50%;
-    top: 50%;
+    left: 50% !important;
+    top: 50% !important;
     width: 100%;
     height: 100%;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
## Overview
After getting feedback that the player wasn't working in some cases (international, first render, with text tracks, only in Safari), we hit up Brightcove and their resolution was to add `.vjs-tech` to the `<video>` tag.  So this is doing just that.

## Risks
Medium - Unsure if there is any associated risk to applying a very generic class (that is seen elsewhere in the dynamically generated markup by Brightcove's player) to something that has not had it before.  Will mitigate with manual testing.

## Changes
n/a

## Breaking change?
Backwards Compatible
