### PR TITLE
Changing base url based on develop to main name change

### DIFF
--- a/src/utils/SourceLink.js
+++ b/src/utils/SourceLink.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 
-const REPO_BASE_URL = 'https://github.com/yankaindustries/mc-components/blob/develop/src/'
+const REPO_BASE_URL = 'https://github.com/yankaindustries/mc-components/blob/main/src/'
 
 const SourceLink = ({ path }) =>
   <a


### PR DESCRIPTION
## Overview
We've updated the default branch name a few times (from develop, to master, to main).  The helper to render the "view source" button on each component was never updated.  This updates that button so you can now link back to the source as expected.

## Risks
None

## Changes
N/A

## Issue
N/A

## Breaking change?
Backwards compatible