### PR TITLE
Adding a width to the background container to deal with content overflow

### DIFF
--- a/src/styles/components/_background.scss
+++ b/src/styles/components/_background.scss
@@ -19,6 +19,7 @@
 
   &__content {
     flex: 1;
+    width: 100%;
   }
 
   &.mc-background--position {


### PR DESCRIPTION
## Overview
Fix for https://github.com/yankaindustries/mc-components/issues/766 - Issue with nesting `row` and `col` classes inside of the background component led to overflow issues because of inherited width values.

## Risks
Low

## Changes
![image](https://user-images.githubusercontent.com/505670/97332852-27ce5180-1838-11eb-88fd-f706b2178911.png)
![image](https://user-images.githubusercontent.com/505670/97332869-2e5cc900-1838-11eb-839e-7f8259c40d6d.png)


## Issue
https://github.com/yankaindustries/mc-components/issues/766

## Breaking change?
Backwards Compatible