### PR TITLE
adding FormGroup to CheckboxField so that it may show an error state

### DIFF
--- a/src/components/Checkbox/index.js
+++ b/src/components/Checkbox/index.js
@@ -14,16 +14,23 @@ export default class Checkbox extends PureComponent {
     name: PropTypes.string,
 
     onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
   }
 
-  handleClick = (e) => {
+  handleClick = (event) => {
     const {
       checked,
       disabled,
       onChange,
+      onFocus,
+      onBlur,
     } = this.props
 
-    e.preventDefault()
+    event.preventDefault()
+
+    if (onFocus) onFocus(event)
+    if (onBlur) onBlur(event)
 
     return !disabled && onChange(!checked)
   }

--- a/src/components/CheckboxField/index.js
+++ b/src/components/CheckboxField/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Checkbox from '../Checkbox'
+import FormGroup from '../FormGroup'
 
 
 const INPUT_PROP_TYPE = PropTypes.shape({
@@ -20,13 +21,17 @@ const CheckboxField = ({
     value,
     ...input
   },
+  meta,
   ...props
 }) => (
-  <Checkbox
-    checked={!!value}
-    {...input}
-    {...props}
-  />
+  <FormGroup {...input} {...meta}>
+    <Checkbox
+      checked={!!value}
+      {...input}
+      {...meta}
+      {...props}
+    />
+  </FormGroup>
 )
 
 CheckboxField.propTypes = {

--- a/src/components/CheckboxField/index.stories.js
+++ b/src/components/CheckboxField/index.stories.js
@@ -23,6 +23,9 @@ const Form = reduxForm({
   initialValues: {
     terms: true,
   },
+  validate: () => ({
+    error: 'Something is wrong here...',
+  }),
 })(
   () =>
     <div className='container'>
@@ -56,6 +59,18 @@ const Form = reduxForm({
             lobster)
           '
         />
+
+        <hr className='mc-separator mc-mb-4' />
+
+        <Field
+          component={CheckboxField}
+          name='error'
+          label='
+            This checkbox has an error
+          '
+        />
+
+        <hr className='mc-separator mc-mb-4' />
 
         <Field
           component={CheckboxField}


### PR DESCRIPTION
## Overview
CheckboxFields don't inherently display their errors like InputField and SelectFields do.  This means that any case where something like a CheckboxField is required and should be displaying an error has to be handled manually.  By wrapping it in a FormGroup with no label, we're able to get any wrapping context (error, warning, help, etc) that should come with the input.

## Risks
Low - existing checkboxes with errors might display them now if they didn't before

## Changes

![image](https://user-images.githubusercontent.com/249444/98866144-598f0d00-2421-11eb-86fa-8be67dfb9983.png)


## Breaking change?
Backwards Compatible
