### PR TITLE
Fixing dropdown component resize issue, adding flip prop

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -18,11 +18,13 @@ export default class Dropdown extends PureComponent {
   static propTypes = {
     children: PROP_TYPE_CHILDREN,
     fixed: PropTypes.bool,
+    autoFlip: PropTypes.bool,
     placement: PropTypes.string,
   }
 
   static defaultProps = {
     fixed: false,
+    autoFlip: true,
     placement: 'bottom-start',
   }
 
@@ -65,7 +67,7 @@ export default class Dropdown extends PureComponent {
   }
 
   renderDropdown = () => {
-    const { fixed, placement } = this.props
+    const { fixed, autoFlip, placement } = this.props
 
     this.tooltip = new Popper(
       findDOMNode(this.toggleRef.current),
@@ -74,6 +76,9 @@ export default class Dropdown extends PureComponent {
         placement,
         positionFixed: fixed || window.innerWidth <= 576,
         modifiers: {
+          flip: {
+            enabled: autoFlip,
+          },
           applyStyle: {
             enabled: true,
             fn: this.applyStyle,

--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -147,6 +147,7 @@
     width: 100%;
     top: 0;
     left: 0;
+    transform: none !important; /* stylelint-disable-line declaration-no-important */
     overflow-x: hidden;
     overflow-y: auto;
 


### PR DESCRIPTION
## Overview
Address some edge case resizing issues with the Dropdown component, and add a new `autoFlip` prop that has the ability to `disable` the autoflip functionality of the dropdown.

## Risks
Low

## Changes
Fixes this issue:
![Kapture 2019-07-22 at 12 33 44](https://user-images.githubusercontent.com/505670/61659705-fe119c80-ac7c-11e9-941d-b602d81a5ac8.gif)

## Issue
https://github.com/yankaindustries/mc-components/issues/524

## Breaking change?
Backwards Compatible
