### PR TITLE
Add new background colors

### DIFF
--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -14,8 +14,10 @@ export default class Background extends PureComponent {
       'dark',
       'medium',
       'light',
+      'light-medium',
       'transparent',
       'dim',
+      'primary',
     ]),
     element: PropTypes.oneOfType([
       PropTypes.func,

--- a/src/components/Background/index.stories.js
+++ b/src/components/Background/index.stories.js
@@ -111,11 +111,44 @@ storiesOf('Components|Background', module)
             <div style={{ background: '#31333b', padding: '1em' }}>
               <div className='row mc-text--center'>
                 <div className='col-4'>
+                  <Background color='transparent'>
+                    <br />
+                    transparent
+                    <br />
+                    (0%)
+                    <br />
+                    <br />
+                  </Background>
+                </div>
+
+                <div className='col-4'>
+                  <Background color='primary'>
+                    <br />
+                    primary
+                    <br />
+                    ($mc-color-primary, 100%)
+                    <br />
+                    <br />
+                  </Background>
+                </div>
+
+                <div className='col-4'>
                   <Background color='light' className='mc-invert'>
                     <br />
                     light
                     <br />
                     ($mc-color-light, 100%)
+                    <br />
+                    <br />
+                  </Background>
+                </div>
+
+                <div className='col-4'>
+                  <Background color='light-medium'>
+                    <br />
+                    light-medium
+                    <br />
+                    ($mc-color-gray-200, 100%)
                     <br />
                     <br />
                   </Background>
@@ -133,33 +166,22 @@ storiesOf('Components|Background', module)
                 </div>
 
                 <div className='col-4'>
-                  <Background color='dark'>
-                    <br />
-                    dark
-                    <br />
-                    ($mc-color-dark, 100%)
-                    <br />
-                    <br />
-                  </Background>
-                </div>
-
-                <div className='col-4'>
-                  <Background color='transparent'>
-                    <br />
-                    transparent
-                    <br />
-                    (0%)
-                    <br />
-                    <br />
-                  </Background>
-                </div>
-
-                <div className='col-4'>
                   <Background color='dim'>
                     <br />
                     dim
                     <br />
                     ($mc-color-dark, 70%)
+                    <br />
+                    <br />
+                  </Background>
+                </div>
+
+                <div className='col-4'>
+                  <Background color='dark'>
+                    <br />
+                    dark
+                    <br />
+                    ($mc-color-dark, 100%)
                     <br />
                     <br />
                   </Background>

--- a/src/styles/components/_background.scss
+++ b/src/styles/components/_background.scss
@@ -128,6 +128,14 @@
     background: $mc-color-gray-100;
   }
 
+  &--color-light-medium {
+    background: $mc-color-gray-200;
+  }
+
+  &--color-primary {
+    background: $mc-color-primary;
+  }
+
   &--color-dark {
     background: $mc-color-dark;
   }


### PR DESCRIPTION
## Overview
I notice that we have a lot of css code where we're using `background-color: $mc-color-primary` and `background-color: $mc-color-gray-200` so I'm adding `$mc-color-primary` as `color='primary'` and `$mc-color-gray-200` as `color='light-medium'` to Background component. 

Note: I'm not sure about calling light medium to gray-200. Other name options?
For future: Would be good to have a way to add custom colors to this background component. 

## Risks
Low. Adding two new colors to the Background component.

## Changes
Before
![image](https://user-images.githubusercontent.com/43350253/103539532-08c2f000-4e77-11eb-8ca2-6feb4e1c5a3e.png)


After 
<img width="1131" alt="Screen Shot 2021-01-04 at 9 24 37 AM" src="https://user-images.githubusercontent.com/43350253/103538892-d795f000-4e75-11eb-92c6-8ad43e91bc9a.png">
Note: I reordered the existing colors in storybook.

## Breaking change?
Backwards Compatible
