### PR TITLE
CheckboxField to work with both redux-form and final-form

### DIFF
--- a/src/components/CheckboxField/index.js
+++ b/src/components/CheckboxField/index.js
@@ -26,10 +26,10 @@ const CheckboxField = ({
 }) => (
   <FormGroup {...input} {...meta}>
     <Checkbox
-      checked={!!value}
       {...input}
       {...meta}
       {...props}
+      checked={!!value}
     />
   </FormGroup>
 )

--- a/src/components/CheckboxField/index.stories.js
+++ b/src/components/CheckboxField/index.stories.js
@@ -1,11 +1,8 @@
 import React from 'react'
-import { createStore, combineReducers } from 'redux'
-import { Provider } from 'react-redux'
 import {
-  reducer as formReducer,
-  reduxForm,
+  Form,
   Field,
-} from 'redux-form'
+} from 'react-final-form'
 import { storiesOf } from '@storybook/react'
 
 import withAddons from '../../utils/withAddons'
@@ -15,19 +12,11 @@ import InvertedMirror from '../../utils/InvertedMirror'
 import CheckboxField from '../CheckboxField'
 
 
-const reducer = combineReducers({ form: formReducer })
-const store = createStore(reducer)
-
-const Form = reduxForm({
-  form: 'checkbox',
-  initialValues: {
-    terms: true,
-  },
-  validate: () => ({
-    error: 'Something is wrong here...',
-  }),
-})(
-  () =>
+storiesOf('Components|Forms/Checkbox', module)
+  .add('CheckboxField', withAddons({
+    path: 'components/CheckboxField/index.stories.js',
+    component: CheckboxField,
+  })(() => (
     <div className='container'>
       <DocHeader
         title='CheckboxField'
@@ -35,72 +24,67 @@ const Form = reduxForm({
       />
 
       <InvertedMirror>
-        <Field
-          component={CheckboxField}
-          name='salt'
-          label='Salt'
-          checked
-        />
+        <Form
+          initialValues={{ salt: true, disabledChecked: true }}
+          onSubmit={console.log}
+          render={({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <Field
+                component={CheckboxField}
+                name='salt'
+                label='Salt'
+              />
 
-        <Field
-          component={CheckboxField}
-          name='pepper'
-          label='Freshly ground black pepper'
-        />
+              <Field
+                component={CheckboxField}
+                name='pepper'
+                label='Freshly ground black pepper'
+              />
 
-        <Field
-          component={CheckboxField}
-          name='longer'
-          label='
-            1 heaping cup cooked lobster meat, shells removed
-            and reserved for sauce (this amount is equal to
-            claw, knuckle and leg meat from two 11⁄2 lb lobsters
-            OR all meat including tail from one 11⁄2 lb
-            lobster)
-          '
-        />
+              <Field
+                component={CheckboxField}
+                name='longer'
+                label='
+                  1 heaping cup cooked lobster meat, shells removed
+                  and reserved for sauce (this amount is equal to
+                  claw, knuckle and leg meat from two 11⁄2 lb lobsters
+                  OR all meat including tail from one 11⁄2 lb
+                  lobster)
+                '
+              />
 
-        <hr className='mc-separator mc-mb-4' />
+              <hr className='mc-separator mc-mb-4' />
 
-        <Field
-          component={CheckboxField}
-          name='error'
-          label='
-            This checkbox has an error
-          '
-        />
+              <Field
+                component={CheckboxField}
+                name='error'
+                label='
+                  This checkbox has an error
+                '
+              />
 
-        <hr className='mc-separator mc-mb-4' />
+              <hr className='mc-separator mc-mb-4' />
 
-        <Field
-          component={CheckboxField}
-          name='disabled'
-          disabled
-          label='
-            This checkbox is disabled
-          '
-        />
+              <Field
+                component={CheckboxField}
+                name='disabled'
+                disabled
+                label='
+                  This checkbox is disabled
+                '
+              />
 
-        <Field
-          component={CheckboxField}
-          name='disabledChecked'
-          disabled
-          checked
-          label='
-            This checkbox is disabled but checked
-          '
+              <Field
+                component={CheckboxField}
+                name='disabledChecked'
+                disabled
+                label='
+                  This checkbox is disabled but checked
+                '
+              />
+            </form>
+          )}
         />
       </InvertedMirror>
-    </div>,
-)
-
-
-storiesOf('Components|Forms/Checkbox', module)
-  .add('CheckboxField', withAddons({
-    path: 'components/CheckboxField/index.stories.js',
-    component: CheckboxField,
-  })(() => (
-    <Provider store={store}>
-      <Form />
-    </Provider>
+    </div>
   )))


### PR DESCRIPTION
## Overview
`CheckboxField` was not working correctly with `final-form` implementations. We'd have to handle the checked state manually instead of relying on the controlled aspect of `final-form.  The documentation for `CheckboxField` has also been updated to use `final-form`.

## Risks
Medium - existing implementations of `final-form` that use the `CheckboxField` should be verified, since overriding checked state is no longer necessary.  However, this should be backwards compatible.

## Issue
<Does this PR fix an existing issue? If so, link to it here>

## Breaking change?
Backwards Compatible
